### PR TITLE
Remove unused analytics entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "route66web",
   "version": "1.0.0",
   "description": "",
-  "main": "analytics-init.js",
   "dependencies": {
     "braces": "^3.0.3",
     "detect-libc": "^2.0.3",
@@ -49,9 +48,6 @@
   "author": "",
   "license": "ISC",
   "type": "module",
-  "exports": {
-    ".": "./analytics-init.js"
-  },
   "bugs": {
     "url": "https://github.com/Christoph9211/route66web/issues"
   },


### PR DESCRIPTION
## Summary
- delete `main` pointing to removed analytics initialization
- remove `exports` field referencing `analytics-init.js`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68486e12a8248329bf4bdd213a868855