### PR TITLE
Add optional product status banner

### DIFF
--- a/app.jsx
+++ b/app.jsx
@@ -241,7 +241,8 @@ function App() {
                     isMobileMenuOpen: !prevState.isMobileMenuOpen,
                   }))
                 }
-                className="inline-flex items-center justify-center p-2 rounded-md dark-mode-text hover:text-primary focus:outline-none"                aria-label={
+                className="inline-flex items-center justify-center p-2 rounded-md dark-mode-text hover:text-primary focus:outline-none"
+                aria-label={
                   appState.isMobileMenuOpen
                     ? "Close main menu"
                     : "Open main menu"
@@ -1047,9 +1048,14 @@ function ProductCard({ product }) {
   // It also needs to dynamically calculate the price based on the selected flavor and size
   return (
     <div
-      className="group product-card p-4 bg-gray-50 dark:bg-gray-700 rounded-lg shadow"
+      className="relative group product-card p-4 bg-gray-50 dark:bg-gray-700 rounded-lg shadow"
       // This class is for the card shadow effect
     >
+      {product.banner && (
+        <div className="product-banner" aria-label={product.banner}>
+          {product.banner}
+        </div>
+      )}
       <img
         src={
           // If the product has an image, use it
@@ -1068,9 +1074,7 @@ function ProductCard({ product }) {
           e.target.src = "/assets/images/placeholder.webp";
         }}
       />
-      <h3 className="text-lg font-bold dark-mode-text">
-        {product.name}
-      </h3>
+      <h3 className="text-lg font-bold dark-mode-text">{product.name}</h3>
       <p className="mt-1 text-xs text-gray-500 dark:text-gray-300">
         {product.category}
       </p>
@@ -1118,14 +1122,20 @@ function ProductCard({ product }) {
               className="block text-xs text-gray-600 dark:text-gray-300 mb-1"
             >
               {/* Use 'Strain' for Vapes & Carts and Other, otherwise 'Size' */}
-              {['Vapes & Carts', 'Other'].includes(product.category) ? 'Strain:' : 'Size:'}
+              {["Vapes & Carts", "Other"].includes(product.category)
+                ? "Strain:"
+                : "Size:"}
             </label>
             <select
               id={`size-${product.name}`}
               className="w-full p-2 rounded border border-gray-300 dark:bg-gray-800 dark:text-white"
               value={selectedSize}
               onChange={(e) => setSelectedSize(e.target.value)}
-              aria-label={['Vapes & Carts', 'Other'].includes(product.category) ? 'Select strain' : 'Select size'}
+              aria-label={
+                ["Vapes & Carts", "Other"].includes(product.category)
+                  ? "Select strain"
+                  : "Select size"
+              }
             >
               {product.size_options.map((size) => (
                 <option key={size} value={size}>
@@ -1183,8 +1193,8 @@ function ProductCard({ product }) {
           ></i>
         ))}
         <span className="ml-1 text-xs text-gray-700 dark:text-gray-300">
-          {/* Show the rating number */}
-          ({product.rating || (product.ratings && product.ratings[0]) || 5})
+          {/* Show the rating number */}(
+          {product.rating || (product.ratings && product.ratings[0]) || 5})
         </span>
       </div>
     </div>

--- a/public/products/products.json
+++ b/public/products/products.json
@@ -4,7 +4,8 @@
     "category": "Concentrates",
     "size_options": ["1 gram"],
     "prices": { "1 gram": 35.0 },
-    "thca_percentage": 98.1
+    "thca_percentage": 98.1,
+    "banner": "Coming Soon"
   },
   {
     "name": "Blueberry Diesel",
@@ -142,7 +143,11 @@
   {
     "name": "Infused Preroll",
     "category": "Other",
-    "size_options": ["Candy Runtz", "Diamond Watermelon", "Rainbow Sherbert Caviar"],
+    "size_options": [
+      "Candy Runtz",
+      "Diamond Watermelon",
+      "Rainbow Sherbert Caviar"
+    ],
     "prices": {
       "Candy Runtz": 10.0,
       "Diamond Watermelon": 12.0,
@@ -163,7 +168,20 @@
   {
     "name": "1 Gram Cart",
     "category": "Vapes & Carts",
-    "size_options": ["Blue Walker (Sativa)", "Bomb Pop (Indica)", "Cranberry Haze (Sativa)", "Cherry Cookies (Indica)", "Cherry Pie (Sativa)", "Gelato (Hybrid)", "Lemon Cake (Hybrid)", "Mango Tango (Indica)", "Trainwreck (Hybrid)", "Tropical Cherries (Sativa)", "Wedding Cake (Indica)", "White Fire Zkittles (Hybrid)"],
+    "size_options": [
+      "Blue Walker (Sativa)",
+      "Bomb Pop (Indica)",
+      "Cranberry Haze (Sativa)",
+      "Cherry Cookies (Indica)",
+      "Cherry Pie (Sativa)",
+      "Gelato (Hybrid)",
+      "Lemon Cake (Hybrid)",
+      "Mango Tango (Indica)",
+      "Trainwreck (Hybrid)",
+      "Tropical Cherries (Sativa)",
+      "Wedding Cake (Indica)",
+      "White Fire Zkittles (Hybrid)"
+    ],
     "prices": {
       "Blue Walker (Sativa)": 24.0,
       "Bomb Pop (Indica)": 16.0,
@@ -183,7 +201,13 @@
   {
     "name": "1 Gram Disposable",
     "category": "Vapes & Carts",
-    "size_options": ["Sour Diesel Live Resin", "Sour Pebbles (Sativa)", "Cherry Cookies (Indica)", "Tropical Cherries (Sativa)", "Watermelon OG (Indica)"],
+    "size_options": [
+      "Sour Diesel Live Resin",
+      "Sour Pebbles (Sativa)",
+      "Cherry Cookies (Indica)",
+      "Tropical Cherries (Sativa)",
+      "Watermelon OG (Indica)"
+    ],
     "prices": {
       "Sour Diesel Live Resin": 35.0,
       "Sour Pebbles (Sativa)": 30.0,
@@ -195,7 +219,15 @@
   {
     "name": "2 Gram Vape",
     "category": "Vapes & Carts",
-    "size_options": ["Runtz", "Chemdawg", "Cherry Cookies", "Green Crack", "Blueberry", "Grape Ape", "Sunset Sherbet"],
+    "size_options": [
+      "Runtz",
+      "Chemdawg",
+      "Cherry Cookies",
+      "Green Crack",
+      "Blueberry",
+      "Grape Ape",
+      "Sunset Sherbet"
+    ],
     "prices": {
       "Runtz": 30.0,
       "Chemdawg": 30.0,
@@ -204,7 +236,7 @@
       "Blueberry": 30.0,
       "Grape Ape": 30.0,
       "Sunset Sherbet": 30.0
-    }
+    },
+    "banner": "Out of Stock"
   }
-  
 ]

--- a/styles.css
+++ b/styles.css
@@ -2,6 +2,19 @@
 .product-card {
   transition: transform 0.3s, box-shadow 0.3s;
 }
+/* Small banner that can appear in the corner of a product card */
+.product-banner {
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: 0.25rem 0.5rem;
+  background-color: rgba(0, 0, 0, 0.75);
+  color: #ffffff;
+  font-size: 0.75rem;
+  font-weight: bold;
+  text-transform: uppercase;
+  border-bottom-right-radius: 0.25rem;
+}
 /* .product-card:hover {
   transform: translateY(-5px);
 } */


### PR DESCRIPTION
## Summary
- add CSS for banner overlay on product cards
- show banner in `ProductCard` when provided
- mark a couple sample products with banner text

## Testing
- `npm run lint` *(fails: cannot find eslint config)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6851cd056fe0832988beca59fdfdebee