### PR TITLE
Add variant banner support

### DIFF
--- a/app.jsx
+++ b/app.jsx
@@ -1040,6 +1040,31 @@ function ProductCard({ product }) {
     price = product.price;
   }
 
+  // Determine banner based on selected variant
+  let banner = product.banner;
+  let bannerKey = null;
+  if (combinedOptions.length > 0 && selectedCombo) {
+    bannerKey = selectedCombo.label;
+  } else if (selectedSize) {
+    bannerKey = selectedSize;
+  } else if (selectedFlavor) {
+    bannerKey = selectedFlavor;
+  }
+  if (bannerKey && product.availability) {
+    if (product.availability[bannerKey]) {
+      banner = product.availability[bannerKey];
+    } else if (
+      selectedCombo &&
+      product.availability[selectedCombo.size]
+    ) {
+      banner = product.availability[selectedCombo.size];
+    } else if (selectedFlavor && product.availability[selectedFlavor]) {
+      banner = product.availability[selectedFlavor];
+    } else if (selectedSize && product.availability[selectedSize]) {
+      banner = product.availability[selectedSize];
+    }
+  }
+
   // Render a product card with the given product data
   // This component is complicated because it needs to handle three different cases:
   // 1. The product has both flavors and size options
@@ -1051,9 +1076,9 @@ function ProductCard({ product }) {
       className="relative group product-card p-4 bg-gray-50 dark:bg-gray-700 rounded-lg shadow"
       // This class is for the card shadow effect
     >
-      {product.banner && (
-        <div className="product-banner" aria-label={product.banner}>
-          {product.banner}
+      {banner && (
+        <div className="product-banner" aria-label={banner}>
+          {banner}
         </div>
       )}
       <img

--- a/public/products/products.json
+++ b/public/products/products.json
@@ -214,6 +214,10 @@
       "Cherry Cookies (Indica)": 30.0,
       "Tropical Cherries (Sativa)": 30.0,
       "Watermelon OG (Indica)": 30.0
+    },
+    "availability": {
+      "Sour Diesel Live Resin": "Coming Soon",
+      "Watermelon OG (Indica)": "Out Stock"
     }
   },
   {
@@ -236,6 +240,10 @@
       "Blueberry": 30.0,
       "Grape Ape": 30.0,
       "Sunset Sherbet": 30.0
+    },
+    "availability": {
+      "Runtz": "Out Stock",
+      "Chemdawg": "Coming Soon"
     },
     "banner": "Out of Stock"
   }


### PR DESCRIPTION
## Summary
- show banner for selected dropdown option if availability is specified
- mark example variants with Coming Soon or Out Stock statuses

## Testing
- `npm run lint` *(fails: parsing error)*
- `npm run build` *(fails: cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6851cfcc962c8329bd11d5867b9c2706