### PR TITLE
Remove vercel insights script

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,7 +87,6 @@
           (window.vaq = window.vaq || []).push(arguments);
         };
     </script>
-    <script defer src="/_vercel/insights/script.js"></script>
   </head>
 
   <body class="font-sans antialiased">


### PR DESCRIPTION
## Summary
- remove vercel insights script to stop accessibility warnings

## Testing
- `npm run lint` *(fails: Parsing error in app.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68612be2b4e48329960fd73bcf09500b