### PR TITLE
Enhance UI with dark mode toggle

### DIFF
--- a/app.jsx
+++ b/app.jsx
@@ -7,9 +7,19 @@ function App() {
     products: [],
     categories: [],
     loading: true,
+    isDarkMode: false,
   });
 
   React.useEffect(() => {
+    const storedTheme = localStorage.getItem("theme");
+    if (
+      storedTheme === "dark" ||
+      (!storedTheme && window.matchMedia("(prefers-color-scheme: dark)").matches)
+    ) {
+      document.documentElement.classList.add("dark");
+      setAppState((prevState) => ({ ...prevState, isDarkMode: true }));
+    }
+
     const verifiedAge = localStorage.getItem("ageVerified");
     if (verifiedAge) {
       setAppState((prevState) => ({
@@ -112,6 +122,20 @@ function App() {
     } else {
       setAppState((prevState) => ({ ...prevState, age: 0 }));
     }
+  };
+
+  const toggleDarkMode = () => {
+    setAppState((prevState) => {
+      const newMode = !prevState.isDarkMode;
+      if (newMode) {
+        document.documentElement.classList.add("dark");
+        localStorage.setItem("theme", "dark");
+      } else {
+        document.documentElement.classList.remove("dark");
+        localStorage.setItem("theme", "light");
+      }
+      return { ...prevState, isDarkMode: newMode };
+    });
   };
 
   const filteredProducts =
@@ -232,6 +256,16 @@ function App() {
               >
                 Contact
               </a>
+              <button
+                onClick={toggleDarkMode}
+                className="dark-mode-text hover:text-primary focus:outline-none"
+              >
+                <i
+                  className={`fas ${appState.isDarkMode ? "fa-sun" : "fa-moon"}`}
+                  aria-hidden="true"
+                ></i>
+                <span className="sr-only">Toggle dark mode</span>
+              </button>
             </div>
             {/* Mobile menu button */}
             <div className="flex md:hidden items-center">
@@ -253,6 +287,16 @@ function App() {
                   aria-hidden="true"
                   tabIndex="-1"
                 ></i>
+              </button>
+              <button
+                onClick={toggleDarkMode}
+                className="ml-4 dark-mode-text hover:text-primary focus:outline-none"
+              >
+                <i
+                  className={`fas ${appState.isDarkMode ? "fa-sun" : "fa-moon"}`}
+                  aria-hidden="true"
+                ></i>
+                <span className="sr-only">Toggle dark mode</span>
               </button>
             </div>
           </div>
@@ -284,6 +328,13 @@ function App() {
               >
                 Contact
               </a>
+              <button
+                onClick={toggleDarkMode}
+                className="w-full flex justify-start dark-mode-text hover:text-primary px-3 py-2 rounded-md text-base font-medium"
+              >
+                <i className={`fas ${appState.isDarkMode ? 'fa-sun' : 'fa-moon'} mr-2`} aria-hidden="true"></i>
+                Toggle Theme
+              </button>
             </div>
           </div>
         )}

--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
     <!-- Google Fonts -->
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Montserrat:wght@400;500;600;700&display=swap"
     />
 
     <!-- Analytics Initialization -->
@@ -86,10 +86,16 @@
     <script defer src="/_vercel/insights/script.js"></script>
   </head>
 
-  <body class="font-sans antialiased">
+  <body class="font-sans antialiased scroll-smooth">
     <main role="main">
       <div id="root"></div>
     </main>
+    <script>
+      const savedTheme = localStorage.getItem('theme');
+      if (savedTheme === 'dark') {
+        document.documentElement.classList.add('dark');
+      }
+    </script>
     <!-- React App -->
     <script type="module" src="/app.jsx"></script>
 

--- a/tailwind-config.js
+++ b/tailwind-config.js
@@ -1,5 +1,5 @@
 tailwind.config = {
-  darkMode: "media",
+  darkMode: "class",
   theme: {
     extend: {
       colors: {
@@ -8,7 +8,7 @@ tailwind.config = {
         accent: "#3A9A2A", // Updated accent color for better contrast
       },
       fontFamily: {
-        sans: ["Montserrat", "sans-serif"],
+        sans: ["Inter", "Montserrat", "sans-serif"],
       },
     },
   },


### PR DESCRIPTION
## Summary
- add Inter font and smooth scrolling
- support persistent theme toggling via script
- switch Tailwind to `class` dark mode and use Inter font
- add responsive dark mode toggle buttons

## Testing
- `npm run lint` *(fails: Parsing error, tailwind not defined)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6874b38272c48329a64fbaa48d640474