### PR TITLE
Enhance style with dark mode toggle

### DIFF
--- a/app.jsx
+++ b/app.jsx
@@ -1,4 +1,3 @@
-
 function App() {
   const [appState, setAppState] = React.useState({
     isMobileMenuOpen: false,
@@ -8,6 +7,22 @@ function App() {
     categories: [],
     loading: true,
   });
+
+  const [isDarkMode, setIsDarkMode] = React.useState(() => {
+    const stored = localStorage.getItem("theme");
+    if (stored) return stored === "dark";
+    return window.matchMedia("(prefers-color-scheme: dark)").matches;
+  });
+
+  React.useEffect(() => {
+    if (isDarkMode) {
+      document.documentElement.classList.add("dark");
+      localStorage.setItem("theme", "dark");
+    } else {
+      document.documentElement.classList.remove("dark");
+      localStorage.setItem("theme", "light");
+    }
+  }, [isDarkMode]);
 
   React.useEffect(() => {
     const verifiedAge = localStorage.getItem("ageVerified");
@@ -118,7 +133,7 @@ function App() {
     appState.selectedCategory === "all"
       ? appState.products
       : appState.products.filter(
-          (product) => product.category === appState.selectedCategory,
+          (product) => product.category === appState.selectedCategory
         );
 
   if (appState.age === null) {
@@ -233,8 +248,18 @@ function App() {
                 Contact
               </a>
             </div>
-            {/* Mobile menu button */}
-            <div className="flex md:hidden items-center">
+            <div className="flex items-center space-x-4">
+              <button
+                onClick={() => setIsDarkMode((d) => !d)}
+                className="dark-mode-text hover:text-primary focus:outline-none"
+                aria-label="Toggle dark mode"
+              >
+                <i
+                  className={`fas ${isDarkMode ? "fa-sun" : "fa-moon"} text-xl`}
+                  aria-hidden="true"
+                  tabIndex="-1"
+                ></i>
+              </button>
               <button
                 type="button"
                 onClick={() =>
@@ -243,13 +268,18 @@ function App() {
                     isMobileMenuOpen: !prevState.isMobileMenuOpen,
                   }))
                 }
-                className="inline-flex items-center justify-center p-2 rounded-md dark-mode-text hover:text-primary focus:outline-none"
+                className="inline-flex md:hidden items-center justify-center p-2 rounded-md dark-mode-text hover:text-primary focus:outline-none"
                 aria-label={
-                  appState.isMobileMenuOpen ? "Close main menu" : "Open main menu"
+                  appState.isMobileMenuOpen
+                    ? "Close main menu"
+                    : "Open main menu"
                 }
-                aria-expanded={appState.isMobileMenuOpen ? 'true' : 'false'}>
+                aria-expanded={appState.isMobileMenuOpen ? "true" : "false"}
+              >
                 <i
-                  className={`fas ${appState.isMobileMenuOpen ? "fa-times" : "fa-bars"} text-xl`}
+                  className={`fas ${
+                    appState.isMobileMenuOpen ? "fa-times" : "fa-bars"
+                  } text-xl`}
                   aria-hidden="true"
                   tabIndex="-1"
                 ></i>
@@ -331,7 +361,7 @@ function App() {
                     </div>
                     <div className="mt-12 lg:m-0 lg:relative">
                       <div className="mx-auto max-w-md px-4 sm:max-w-2xl sm:px-6 lg:px-0">
-                        <div className="w-full h-64 sm:h-72 md:h-96 rounded-xl shadow-xl bg-gradient-to-br from-green-200 to-green-600 dark:from-green-900 dark:to-green-600 relative overflow-hidden">
+                        <div className="w-full h-64 sm:h-72 md:h-96 rounded-xl shadow-xl bg-gradient-to-br from-primary to-secondary dark:from-secondary dark:to-primary relative overflow-hidden">
                           <div className="absolute inset-0 flex items-center justify-center">
                             <i
                               className="fas fa-cannabis text-white text-9xl opacity-30"
@@ -956,13 +986,13 @@ function ProductCard({ product }) {
         // Store the flavor and size for later use
         flavor,
         size,
-      })),
+      }))
     );
   }
 
   // State for combined selection
   const [selectedCombo, setSelectedCombo] = React.useState(
-    combinedOptions.length > 0 ? combinedOptions[0] : null,
+    combinedOptions.length > 0 ? combinedOptions[0] : null
   );
   // Fallback for only size or only flavor
   const [selectedSize, setSelectedSize] = React.useState(
@@ -970,12 +1000,12 @@ function ProductCard({ product }) {
       product.size_options &&
       product.size_options.length > 0
       ? product.size_options[0]
-      : null,
+      : null
   );
   const [selectedFlavor, setSelectedFlavor] = React.useState(
     !combinedOptions.length && product.flavors && product.flavors.length > 0
       ? product.flavors[0]
-      : null,
+      : null
   );
 
   // Determine price
@@ -1077,7 +1107,7 @@ function ProductCard({ product }) {
             onChange={(e) => {
               // When the user selects a new option, update the selectedCombo state
               const combo = combinedOptions.find(
-                (opt) => opt.label === e.target.value,
+                (opt) => opt.label === e.target.value
               );
               setSelectedCombo(combo);
             }}
@@ -1162,7 +1192,7 @@ function ProductCard({ product }) {
             className={`text-xs ${
               i <
               Math.floor(
-                product.rating || (product.ratings && product.ratings[0]) || 5,
+                product.rating || (product.ratings && product.ratings[0]) || 5
               )
                 ? "fas fa-star text-yellow-600"
                 : "far fa-star text-yellow-600"

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -73,7 +73,7 @@
     <!-- Google Fonts -->
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Montserrat:wght@400;500;600;700&display=swap"
     />
 
     <!-- Analytics Initialization -->
@@ -81,7 +81,11 @@
 
     <!-- Web Analytics -->
     <script>
-      window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };
+      window.va =
+        window.va ||
+        function () {
+          (window.vaq = window.vaq || []).push(arguments);
+        };
     </script>
     <script defer src="/_vercel/insights/script.js"></script>
   </head>
@@ -94,7 +98,11 @@
     <script type="module" src="/app.jsx"></script>
 
     <script>
-      window.si = window.si || function () { (window.siq = window.siq || []).push(arguments); };
+      window.si =
+        window.si ||
+        function () {
+          (window.siq = window.siq || []).push(arguments);
+        };
     </script>
     <script defer src="/_vercel/speed-insights/script.js"></script>
   </body>

--- a/styles.css
+++ b/styles.css
@@ -1,8 +1,6 @@
 /* Custom styles */
 .product-card {
-  transition:
-    transform 0.3s,
-    box-shadow 0.3s;
+  transition: transform 0.3s, box-shadow 0.3s;
 }
 /* Small banner that can appear in the corner of a product card */
 .product-banner {
@@ -17,9 +15,9 @@
   text-transform: uppercase;
   border-bottom-right-radius: 0.25rem;
 }
-/* .product-card:hover {
+.product-card:hover {
   transform: translateY(-5px);
-} */
+}
 
 /* Ensure dark mode text contrast */
 @media (prefers-color-scheme: dark) {

--- a/tailwind-config.js
+++ b/tailwind-config.js
@@ -1,5 +1,5 @@
 tailwind.config = {
-  darkMode: "media",
+  darkMode: "class",
   theme: {
     extend: {
       colors: {
@@ -8,7 +8,7 @@ tailwind.config = {
         accent: "#3A9A2A", // Updated accent color for better contrast
       },
       fontFamily: {
-        sans: ["Montserrat", "sans-serif"],
+        sans: ["Inter", "Montserrat", "sans-serif"],
       },
     },
   },


### PR DESCRIPTION
## Summary
- improve typography by including Inter font
- allow dark mode to be toggled manually
- modernize hero gradient
- add hover effect to product cards

## Testing
- `npm run lint` *(fails: Parsing error in app.jsx)*
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_6874e9a01b248329a755a415b25786f1