### PR TITLE
Fix weekday detection in SEO helpers

### DIFF
--- a/src/utils/seoHelpers.js
+++ b/src/utils/seoHelpers.js
@@ -64,7 +64,9 @@ export const getBusinessHours = () => ({
 
 export const isCurrentlyOpen = () => {
   const now = new Date();
-  const currentDay = now.toLocaleLowerCase().substring(0, 3);
+  const currentDay = now
+    .toLocaleDateString('en-US', { weekday: 'long' })
+    .toLowerCase();
   const currentTime = now.getHours() * 100 + now.getMinutes();
   
   const hours = getBusinessHours();


### PR DESCRIPTION
## Summary
- use `toLocaleDateString` to get full weekday name in `isCurrentlyOpen`

## Testing
- `npm run lint` *(fails: React globals not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68765fc087c88329990a03cfa37b1a84