### PR TITLE
feat: add edibles category

### DIFF
--- a/public/products/json_gen_v2.html
+++ b/public/products/json_gen_v2.html
@@ -196,6 +196,18 @@
       const submitBtn = document.getElementById("submit-btn");
       const cancelEditBtn = document.getElementById("cancel-edit-btn");
 
+      // Default categories for datalist
+      const defaultCategories = [
+        "Concentrates",
+        "Diamonds & Sauce",
+        "Edibles",
+        "Flower",
+        "Other",
+        "Vapes & Carts",
+      ];
+
+      refreshCategoryList();
+
       // --- Utility helpers ---
       const getRank = (p) => {
         if (p.banner === "New") return 0;
@@ -223,7 +235,11 @@
 
       const refreshCategoryList = () => {
         categoryList.innerHTML = "";
-        Array.from(new Set(products.map((p) => p.category)))
+        const categories = new Set([
+          ...defaultCategories,
+          ...products.map((p) => p.category),
+        ]);
+        Array.from(categories)
           .sort()
           .forEach((cat) => {
             const option = document.createElement("option");

--- a/public/products/products.json
+++ b/public/products/products.json
@@ -616,5 +616,18 @@
       "ounce": 150
     },
     "banner": "Out of Stock"
+  },
+  {
+    "name": "Delta-9 Gummies",
+    "category": "Edibles",
+    "size_options": [
+      "10 count",
+      "30 count"
+    ],
+    "prices": {
+      "10 count": 20,
+      "30 count": 50
+    },
+    "banner": "New"
   }
 ]


### PR DESCRIPTION
## Summary
- support a new Edibles product category in the JSON generator
- add sample Edibles item to products.json for easy editing

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6882a8e5ed488329afd5cce4ca75eaa4