### PR TITLE
fix: improve text contrast

### DIFF
--- a/app.jsx
+++ b/app.jsx
@@ -98,7 +98,7 @@ function ProductCard({ product }) {
                 <button
                     className={`rounded-md px-4 py-2 text-sm font-medium transition-colors ${
                         isOutOfStock
-                            ? 'cursor-not-allowed bg-gray-300 text-gray-500'
+                            ? 'cursor-not-allowed bg-gray-300 text-gray-700 dark:bg-gray-600 dark:text-gray-300'
                             : 'bg-green-600 text-white hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2'
                     }`}
                     disabled={isOutOfStock}

--- a/src/components/BreadcrumbNavigation.jsx
+++ b/src/components/BreadcrumbNavigation.jsx
@@ -1,9 +1,7 @@
 import React from 'react'
 
 function BreadcrumbNavigation({ currentPage, category, productName }) {
-    const breadcrumbs = [
-        { label: 'Home', href: '#home', icon: 'fas fa-home' },
-    ]
+    const breadcrumbs = [{ label: 'Home', href: '#home', icon: 'fas fa-home' }]
 
     // Add category if provided
     if (category) {
@@ -24,15 +22,18 @@ function BreadcrumbNavigation({ currentPage, category, productName }) {
     if (breadcrumbs.length <= 1) return null
 
     return (
-        <nav className="bg-gray-50 py-3 dark:bg-gray-800" aria-label="Breadcrumb">
+        <nav
+            className="bg-gray-50 py-3 dark:bg-gray-800"
+            aria-label="Breadcrumb"
+        >
             <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
                 <ol className="flex items-center space-x-2 text-sm">
                     {breadcrumbs.map((crumb, index) => (
                         <li key={index} className="flex items-center">
                             {index > 0 && (
-                                <i 
-                                    className="fas fa-chevron-right mx-2 text-xs text-gray-400" 
-                                    aria-hidden="true" 
+                                <i
+                                    className="fas fa-chevron-right mx-2 text-xs text-gray-500 dark:text-gray-400"
+                                    aria-hidden="true"
                                 />
                             )}
                             {crumb.href ? (
@@ -41,14 +42,20 @@ function BreadcrumbNavigation({ currentPage, category, productName }) {
                                     className="flex items-center text-gray-600 hover:text-green-600 dark:text-gray-300 dark:hover:text-green-400"
                                 >
                                     {crumb.icon && (
-                                        <i className={`${crumb.icon} mr-1`} aria-hidden="true" />
+                                        <i
+                                            className={`${crumb.icon} mr-1`}
+                                            aria-hidden="true"
+                                        />
                                     )}
                                     {crumb.label}
                                 </a>
                             ) : (
-                                <span className="flex items-center text-gray-900 font-medium dark:text-white">
+                                <span className="flex items-center font-medium text-gray-900 dark:text-white">
                                     {crumb.icon && (
-                                        <i className={`${crumb.icon} mr-1`} aria-hidden="true" />
+                                        <i
+                                            className={`${crumb.icon} mr-1`}
+                                            aria-hidden="true"
+                                        />
                                     )}
                                     {crumb.label}
                                 </span>

--- a/src/components/FooterNavigation.jsx
+++ b/src/components/FooterNavigation.jsx
@@ -36,7 +36,10 @@ function FooterNavigation() {
             title: 'Legal',
             links: [
                 { label: 'Privacy Policy', href: '/src/privacy-policy.html' },
-                { label: 'Terms of Service', href: '/src/terms-of-service.html' },
+                {
+                    label: 'Terms of Service',
+                    href: '/src/terms-of-service.html',
+                },
                 { label: 'Age Verification', href: '#age-verification' },
                 { label: 'Compliance', href: '#compliance' },
             ],
@@ -44,23 +47,23 @@ function FooterNavigation() {
     ]
 
     const socialLinks = [
-        { 
-            platform: 'Facebook', 
-            href: 'https://facebook.com/route66hemp', 
+        {
+            platform: 'Facebook',
+            href: 'https://facebook.com/route66hemp',
             icon: 'fab fa-facebook-f',
-            color: 'hover:text-blue-600'
+            color: 'hover:text-blue-600',
         },
-        { 
-            platform: 'Instagram', 
-            href: 'https://instagram.com/route66hemp', 
+        {
+            platform: 'Instagram',
+            href: 'https://instagram.com/route66hemp',
             icon: 'fab fa-instagram',
-            color: 'hover:text-pink-600'
+            color: 'hover:text-pink-600',
         },
-        { 
-            platform: 'Google', 
-            href: 'https://www.google.com/maps/search/Route+66+Hemp+St+Robert+MO', 
+        {
+            platform: 'Google',
+            href: 'https://www.google.com/maps/search/Route+66+Hemp+St+Robert+MO',
             icon: 'fab fa-google',
-            color: 'hover:text-red-600'
+            color: 'hover:text-red-600',
         },
     ]
 
@@ -72,26 +75,39 @@ function FooterNavigation() {
                     {/* Business Info */}
                     <div className="lg:col-span-2">
                         <div className="mb-6">
-                            <div className="flex items-center space-x-3 mb-4">
+                            <div className="mb-4 flex items-center space-x-3">
                                 <div className="flex h-12 w-12 items-center justify-center rounded-full bg-green-600">
-                                    <i className="fas fa-cannabis text-white text-xl" aria-hidden="true" />
+                                    <i
+                                        className="fas fa-cannabis text-xl text-white"
+                                        aria-hidden="true"
+                                    />
                                 </div>
                                 <div>
-                                    <h3 className="text-xl font-bold">Route 66 Hemp</h3>
-                                    <p className="text-gray-300 text-sm">Premium Hemp Products</p>
+                                    <h3 className="text-xl font-bold">
+                                        Route 66 Hemp
+                                    </h3>
+                                    <p className="text-sm text-gray-300">
+                                        Premium Hemp Products
+                                    </p>
                                 </div>
                             </div>
-                            <p className="text-gray-300 mb-6">
-                                Your trusted local hemp store in St Robert, Missouri. 
-                                Serving Pulaski County and the Fort Leonard Wood community 
-                                with quality hemp products since 2025.
+                            <p className="mb-6 text-gray-300">
+                                Your trusted local hemp store in St Robert,
+                                Missouri. Serving Pulaski County and the Fort
+                                Leonard Wood community with quality hemp
+                                products since 2025.
                             </p>
-                            <LocalBusinessInfo variant="minimal" className="text-gray-300" />
+                            <LocalBusinessInfo
+                                variant="minimal"
+                                className="text-gray-300"
+                            />
                         </div>
 
                         {/* Social Links */}
                         <div>
-                            <h4 className="text-lg font-semibold mb-3">Follow Us</h4>
+                            <h4 className="mb-3 text-lg font-semibold">
+                                Follow Us
+                            </h4>
                             <div className="flex space-x-4">
                                 {socialLinks.map((social) => (
                                     <a
@@ -102,7 +118,10 @@ function FooterNavigation() {
                                         className={`flex h-10 w-10 items-center justify-center rounded-full bg-gray-800 text-gray-300 transition-colors ${social.color} hover:bg-gray-700`}
                                         aria-label={`Follow us on ${social.platform}`}
                                     >
-                                        <i className={social.icon} aria-hidden="true" />
+                                        <i
+                                            className={social.icon}
+                                            aria-hidden="true"
+                                        />
                                     </a>
                                 ))}
                             </div>
@@ -112,13 +131,15 @@ function FooterNavigation() {
                     {/* Footer Links */}
                     {footerSections.map((section) => (
                         <div key={section.title}>
-                            <h4 className="text-lg font-semibold mb-4">{section.title}</h4>
+                            <h4 className="mb-4 text-lg font-semibold">
+                                {section.title}
+                            </h4>
                             <ul className="space-y-2">
                                 {section.links.map((link) => (
                                     <li key={link.label}>
                                         <a
                                             href={link.href}
-                                            className="text-gray-300 hover:text-green-400 transition-colors text-sm"
+                                            className="text-sm text-gray-300 transition-colors hover:text-green-400"
                                         >
                                             {link.label}
                                         </a>
@@ -132,17 +153,25 @@ function FooterNavigation() {
                 {/* Bottom Footer */}
                 <div className="mt-12 border-t border-gray-800 pt-8">
                     <div className="flex flex-col items-center justify-between space-y-4 md:flex-row md:space-y-0">
-                        <div className="text-center text-sm text-gray-400 md:text-left">
-                            <p>&copy; 2025 Route 66 Hemp. All rights reserved.</p>
+                        <div className="text-center text-sm text-gray-300 md:text-left">
+                            <p>
+                                &copy; 2025 Route 66 Hemp. All rights reserved.
+                            </p>
                             <p className="mt-1">
                                 Licensed hemp retailer in Missouri | 21+ Only
                             </p>
                         </div>
-                        <div className="flex items-center space-x-6 text-sm text-gray-400">
-                            <a href="/src/privacy-policy.html" className="hover:text-green-400">
+                        <div className="flex items-center space-x-6 text-sm text-gray-300">
+                            <a
+                                href="/src/privacy-policy.html"
+                                className="hover:text-green-400"
+                            >
                                 Privacy
                             </a>
-                            <a href="/src/terms-of-service.html" className="hover:text-green-400">
+                            <a
+                                href="/src/terms-of-service.html"
+                                className="hover:text-green-400"
+                            >
                                 Terms
                             </a>
                             <span>St Robert, MO 65584</span>

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -316,7 +316,7 @@ function Navigation({ products = [] }) {
                                                             item.id
                                                         )
                                                     }
-                                                    className="block px-3 py-2 text-sm text-gray-600 hover:text-green-600 dark:text-gray-400 dark:hover:text-green-400"
+                                                    className="block px-3 py-2 text-sm text-gray-600 hover:text-green-600 dark:text-gray-300 dark:hover:text-green-400"
                                                     role="menuitem"
                                                 >
                                                     {subItem.label}

--- a/src/components/SearchNavigation.jsx
+++ b/src/components/SearchNavigation.jsx
@@ -15,13 +15,18 @@ function SearchNavigation({ products = [] }) {
             return
         }
 
-        const filtered = products.filter(product => 
-            product.name.toLowerCase().includes(query.toLowerCase()) ||
-            product.category.toLowerCase().includes(query.toLowerCase()) ||
-            product.size_options.some(size => 
-                size.toLowerCase().includes(query.toLowerCase())
+        const filtered = products
+            .filter(
+                (product) =>
+                    product.name.toLowerCase().includes(query.toLowerCase()) ||
+                    product.category
+                        .toLowerCase()
+                        .includes(query.toLowerCase()) ||
+                    product.size_options.some((size) =>
+                        size.toLowerCase().includes(query.toLowerCase())
+                    )
             )
-        ).slice(0, 8) // Limit to 8 results
+            .slice(0, 8) // Limit to 8 results
 
         setResults(filtered)
         setSelectedIndex(-1)
@@ -35,13 +40,13 @@ function SearchNavigation({ products = [] }) {
             switch (e.key) {
                 case 'ArrowDown':
                     e.preventDefault()
-                    setSelectedIndex(prev => 
+                    setSelectedIndex((prev) =>
                         prev < results.length - 1 ? prev + 1 : prev
                     )
                     break
                 case 'ArrowUp':
                     e.preventDefault()
-                    setSelectedIndex(prev => prev > 0 ? prev - 1 : -1)
+                    setSelectedIndex((prev) => (prev > 0 ? prev - 1 : -1))
                     break
                 case 'Enter':
                     e.preventDefault()
@@ -65,13 +70,17 @@ function SearchNavigation({ products = [] }) {
     // Close search when clicking outside
     useEffect(() => {
         const handleClickOutside = (event) => {
-            if (searchRef.current && !searchRef.current.contains(event.target)) {
+            if (
+                searchRef.current &&
+                !searchRef.current.contains(event.target)
+            ) {
                 setIsOpen(false)
             }
         }
 
         document.addEventListener('mousedown', handleClickOutside)
-        return () => document.removeEventListener('mousedown', handleClickOutside)
+        return () =>
+            document.removeEventListener('mousedown', handleClickOutside)
     }, [])
 
     const handleResultClick = (product) => {
@@ -88,16 +97,18 @@ function SearchNavigation({ products = [] }) {
 
     const highlightMatch = (text, query) => {
         if (!query) return text
-        
+
         const regex = new RegExp(`(${query})`, 'gi')
         const parts = text.split(regex)
-        
-        return parts.map((part, index) => 
+
+        return parts.map((part, index) =>
             regex.test(part) ? (
                 <mark key={index} className="bg-yellow-200 dark:bg-yellow-800">
                     {part}
                 </mark>
-            ) : part
+            ) : (
+                part
+            )
         )
     }
 
@@ -115,34 +126,46 @@ function SearchNavigation({ products = [] }) {
 
             {/* Search Overlay */}
             {isOpen && (
-                <div className="fixed inset-0 z-50 bg-black bg-opacity-50 flex items-start justify-center pt-20">
-                    <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-full max-w-2xl mx-4">
+                <div className="fixed inset-0 z-50 flex items-start justify-center bg-black bg-opacity-50 pt-20">
+                    <div className="mx-4 w-full max-w-2xl rounded-lg bg-white shadow-xl dark:bg-gray-800">
                         {/* Search Input */}
-                        <div className="p-4 border-b border-gray-200 dark:border-gray-700">
+                        <div className="border-b border-gray-200 p-4 dark:border-gray-700">
                             <div className="relative">
-                                <i className="fas fa-search absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400" aria-hidden="true" />
+                                <i
+                                    className="fas fa-search absolute left-3 top-1/2 -translate-y-1/2 transform text-gray-500 dark:text-gray-300"
+                                    aria-hidden="true"
+                                />
                                 <input
                                     type="text"
                                     placeholder="Search products, categories, or sizes..."
                                     value={query}
                                     onChange={(e) => setQuery(e.target.value)}
-                                    className="w-full pl-10 pr-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-green-500 focus:border-transparent dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+                                    className="w-full rounded-lg border border-gray-300 py-3 pl-10 pr-4 focus:border-transparent focus:ring-2 focus:ring-green-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
                                     autoFocus
                                 />
                                 <button
                                     onClick={() => setIsOpen(false)}
-                                    className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-400 hover:text-gray-600"
+                                    className="absolute right-3 top-1/2 -translate-y-1/2 transform text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-gray-100"
                                 >
-                                    <i className="fas fa-times" aria-hidden="true" />
+                                    <i
+                                        className="fas fa-times"
+                                        aria-hidden="true"
+                                    />
                                 </button>
                             </div>
                         </div>
 
                         {/* Search Results */}
-                        <div ref={resultsRef} className="max-h-96 overflow-y-auto">
+                        <div
+                            ref={resultsRef}
+                            className="max-h-96 overflow-y-auto"
+                        >
                             {query.length >= 2 && results.length === 0 && (
-                                <div className="p-4 text-center text-gray-500 dark:text-gray-400">
-                                    <i className="fas fa-search text-2xl mb-2" aria-hidden="true" />
+                                <div className="p-4 text-center text-gray-600 dark:text-gray-300">
+                                    <i
+                                        className="fas fa-search mb-2 text-2xl"
+                                        aria-hidden="true"
+                                    />
                                     <p>No products found for "{query}"</p>
                                 </div>
                             )}
@@ -151,37 +174,61 @@ function SearchNavigation({ products = [] }) {
                                 <button
                                     key={product.name}
                                     onClick={() => handleResultClick(product)}
-                                    className={`w-full text-left p-4 border-b border-gray-100 hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-700 transition-colors ${
-                                        index === selectedIndex ? 'bg-green-50 dark:bg-green-900' : ''
+                                    className={`w-full border-b border-gray-100 p-4 text-left transition-colors hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-700 ${
+                                        index === selectedIndex
+                                            ? 'bg-green-50 dark:bg-green-900'
+                                            : ''
                                     }`}
                                 >
                                     <div className="flex items-center justify-between">
                                         <div>
                                             <h4 className="font-medium text-gray-900 dark:text-white">
-                                                {highlightMatch(product.name, query)}
+                                                {highlightMatch(
+                                                    product.name,
+                                                    query
+                                                )}
                                             </h4>
                                             <p className="text-sm text-gray-600 dark:text-gray-300">
-                                                {highlightMatch(product.category, query)}
+                                                {highlightMatch(
+                                                    product.category,
+                                                    query
+                                                )}
                                             </p>
-                                            <div className="flex items-center mt-1 text-xs text-gray-500">
-                                                <span>Sizes: {product.size_options.join(', ')}</span>
+                                            <div className="mt-1 flex items-center text-xs text-gray-600 dark:text-gray-300">
+                                                <span>
+                                                    Sizes:{' '}
+                                                    {product.size_options.join(
+                                                        ', '
+                                                    )}
+                                                </span>
                                                 {product.thca_percentage && (
                                                     <span className="ml-2">
-                                                        THCa: {product.thca_percentage}%
+                                                        THCa:{' '}
+                                                        {
+                                                            product.thca_percentage
+                                                        }
+                                                        %
                                                     </span>
                                                 )}
                                             </div>
                                         </div>
                                         <div className="text-right">
                                             <div className="text-sm font-medium text-green-600">
-                                                From ${Math.min(...Object.values(product.prices))}
+                                                From $
+                                                {Math.min(
+                                                    ...Object.values(
+                                                        product.prices
+                                                    )
+                                                )}
                                             </div>
                                             {product.banner && (
-                                                <span className={`inline-block px-2 py-1 text-xs rounded ${
-                                                    product.banner === 'New' 
-                                                        ? 'bg-green-100 text-green-800' 
-                                                        : 'bg-red-100 text-red-800'
-                                                }`}>
+                                                <span
+                                                    className={`inline-block rounded px-2 py-1 text-xs ${
+                                                        product.banner === 'New'
+                                                            ? 'bg-green-100 text-green-800'
+                                                            : 'bg-red-100 text-red-800'
+                                                    }`}
+                                                >
                                                     {product.banner}
                                                 </span>
                                             )}
@@ -193,14 +240,21 @@ function SearchNavigation({ products = [] }) {
 
                         {/* Search Tips */}
                         {query.length < 2 && (
-                            <div className="p-4 text-sm text-gray-500 dark:text-gray-400">
+                            <div className="p-4 text-sm text-gray-600 dark:text-gray-300">
                                 <p className="mb-2">Try searching for:</p>
                                 <div className="flex flex-wrap gap-2">
-                                    {['Flower', 'Concentrates', 'Vapes', 'Edibles', '1 gram', 'Snowcaps'].map(term => (
+                                    {[
+                                        'Flower',
+                                        'Concentrates',
+                                        'Vapes',
+                                        'Edibles',
+                                        '1 gram',
+                                        'Snowcaps',
+                                    ].map((term) => (
                                         <button
                                             key={term}
                                             onClick={() => setQuery(term)}
-                                            className="px-2 py-1 bg-gray-100 rounded text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+                                            className="rounded bg-gray-100 px-2 py-1 text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
                                         >
                                             {term}
                                         </button>


### PR DESCRIPTION
## Summary
- increase contrast for breadcrumb chevron and mobile navigation links
- adjust search modal text and icons for readability across themes
- refine disabled button and footer text colors for light/dark modes

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899945cf3108329a5e6d01592a47976