### PR TITLE
fix: remove duplicate legal links

### DIFF
--- a/src/components/FooterNavigation.jsx
+++ b/src/components/FooterNavigation.jsx
@@ -36,7 +36,10 @@ function FooterNavigation() {
             title: 'Legal',
             links: [
                 { label: 'Privacy Policy', href: '/src/privacy-policy.html' },
-                { label: 'Terms of Service', href: '/src/terms-of-service.html' },
+                {
+                    label: 'Terms of Service',
+                    href: '/src/terms-of-service.html',
+                },
                 { label: 'Age Verification', href: '#age-verification' },
                 { label: 'Compliance', href: '#compliance' },
             ],
@@ -44,23 +47,23 @@ function FooterNavigation() {
     ]
 
     const socialLinks = [
-        { 
-            platform: 'Facebook', 
-            href: 'https://facebook.com/route66hemp', 
+        {
+            platform: 'Facebook',
+            href: 'https://facebook.com/route66hemp',
             icon: 'fab fa-facebook-f',
-            color: 'hover:text-blue-600'
+            color: 'hover:text-blue-600',
         },
-        { 
-            platform: 'Instagram', 
-            href: 'https://instagram.com/route66hemp', 
+        {
+            platform: 'Instagram',
+            href: 'https://instagram.com/route66hemp',
             icon: 'fab fa-instagram',
-            color: 'hover:text-pink-600'
+            color: 'hover:text-pink-600',
         },
-        { 
-            platform: 'Google', 
-            href: 'https://www.google.com/maps/search/Route+66+Hemp+St+Robert+MO', 
+        {
+            platform: 'Google',
+            href: 'https://www.google.com/maps/search/Route+66+Hemp+St+Robert+MO',
             icon: 'fab fa-google',
-            color: 'hover:text-red-600'
+            color: 'hover:text-red-600',
         },
     ]
 
@@ -72,26 +75,39 @@ function FooterNavigation() {
                     {/* Business Info */}
                     <div className="lg:col-span-2">
                         <div className="mb-6">
-                            <div className="flex items-center space-x-3 mb-4">
+                            <div className="mb-4 flex items-center space-x-3">
                                 <div className="flex h-12 w-12 items-center justify-center rounded-full bg-green-600">
-                                    <i className="fas fa-cannabis text-white text-xl" aria-hidden="true" />
+                                    <i
+                                        className="fas fa-cannabis text-xl text-white"
+                                        aria-hidden="true"
+                                    />
                                 </div>
                                 <div>
-                                    <h3 className="text-xl font-bold">Route 66 Hemp</h3>
-                                    <p className="text-gray-300 text-sm">Premium Hemp Products</p>
+                                    <h3 className="text-xl font-bold">
+                                        Route 66 Hemp
+                                    </h3>
+                                    <p className="text-sm text-gray-300">
+                                        Premium Hemp Products
+                                    </p>
                                 </div>
                             </div>
-                            <p className="text-gray-300 mb-6">
-                                Your trusted local hemp store in St Robert, Missouri. 
-                                Serving Pulaski County and the Fort Leonard Wood community 
-                                with quality hemp products since 2025.
+                            <p className="mb-6 text-gray-300">
+                                Your trusted local hemp store in St Robert,
+                                Missouri. Serving Pulaski County and the Fort
+                                Leonard Wood community with quality hemp
+                                products since 2025.
                             </p>
-                            <LocalBusinessInfo variant="minimal" className="text-gray-300" />
+                            <LocalBusinessInfo
+                                variant="minimal"
+                                className="text-gray-300"
+                            />
                         </div>
 
                         {/* Social Links */}
                         <div>
-                            <h4 className="text-lg font-semibold mb-3">Follow Us</h4>
+                            <h4 className="mb-3 text-lg font-semibold">
+                                Follow Us
+                            </h4>
                             <div className="flex space-x-4">
                                 {socialLinks.map((social) => (
                                     <a
@@ -102,7 +118,10 @@ function FooterNavigation() {
                                         className={`flex h-10 w-10 items-center justify-center rounded-full bg-gray-800 text-gray-300 transition-colors ${social.color} hover:bg-gray-700`}
                                         aria-label={`Follow us on ${social.platform}`}
                                     >
-                                        <i className={social.icon} aria-hidden="true" />
+                                        <i
+                                            className={social.icon}
+                                            aria-hidden="true"
+                                        />
                                     </a>
                                 ))}
                             </div>
@@ -112,13 +131,15 @@ function FooterNavigation() {
                     {/* Footer Links */}
                     {footerSections.map((section) => (
                         <div key={section.title}>
-                            <h4 className="text-lg font-semibold mb-4">{section.title}</h4>
+                            <h4 className="mb-4 text-lg font-semibold">
+                                {section.title}
+                            </h4>
                             <ul className="space-y-2">
                                 {section.links.map((link) => (
                                     <li key={link.label}>
                                         <a
                                             href={link.href}
-                                            className="text-gray-300 hover:text-green-400 transition-colors text-sm"
+                                            className="text-sm text-gray-300 transition-colors hover:text-green-400"
                                         >
                                             {link.label}
                                         </a>
@@ -133,18 +154,14 @@ function FooterNavigation() {
                 <div className="mt-12 border-t border-gray-800 pt-8">
                     <div className="flex flex-col items-center justify-between space-y-4 md:flex-row md:space-y-0">
                         <div className="text-center text-sm text-gray-400 md:text-left">
-                            <p>&copy; 2025 Route 66 Hemp. All rights reserved.</p>
+                            <p>
+                                &copy; 2025 Route 66 Hemp. All rights reserved.
+                            </p>
                             <p className="mt-1">
                                 Licensed hemp retailer in Missouri | 21+ Only
                             </p>
                         </div>
-                        <div className="flex items-center space-x-6 text-sm text-gray-400">
-                            <a href="/src/privacy-policy.html" className="hover:text-green-400">
-                                Privacy
-                            </a>
-                            <a href="/src/terms-of-service.html" className="hover:text-green-400">
-                                Terms
-                            </a>
+                        <div className="flex items-center text-sm text-gray-400">
                             <span>St Robert, MO 65584</span>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- remove duplicated privacy and terms links from footer
- rely on legal column for privacy and terms

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a4638532c83299f11164842e0dc8d