### PR TITLE
feat: add cart system

### DIFF
--- a/app.jsx
+++ b/app.jsx
@@ -13,6 +13,10 @@ import LocationContent from './src/components/LocationContent'
 import GoogleBusinessIntegration from './src/components/GoogleBusinessIntegration'
 import LocalBusinessInfo from './src/components/LocalBusinessInfo'
 import StructuredData from './src/components/StructuredData'
+import CartDrawer from './src/components/CartDrawer'
+import CartPage from './src/components/CartPage'
+import { CartProvider } from './src/hooks/useCart'
+import { initCartButtonListener } from './src/utils/cartEvents'
 
 // Import hooks
 import { useNavigation, useKeyboardNavigation } from './src/hooks/useNavigation'
@@ -107,13 +111,20 @@ function ProductCard({ product }) {
                     ${currentPrice?.toFixed(2) || 'N/A'}
                 </div>
                 <button
-                    className={`rounded-md px-4 py-2 text-sm font-medium transition-colors ${
+                    className={`add-to-cart rounded-md px-4 py-2 text-sm font-medium transition-colors ${
                         isOutOfStock
                             ? 'cursor-not-allowed bg-gray-300 text-gray-600 hover:text-red-600'
                             : 'bg-green-600 text-white hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2'
                     }`}
                     disabled={isOutOfStock}
                     aria-label={`Add ${product.name} to cart`}
+                    data-product-id={slugify(product.name)}
+                    data-variant-id={`${slugify(product.name)}_${slugify(selectedSize)}`}
+                    data-name={product.name}
+                    data-price={currentPrice?.toFixed(2) || 0}
+                    data-currency="USD"
+                    data-image=""
+                    data-available={!isOutOfStock}
                 >
                     {isOutOfStock ? 'Out of Stock' : 'Add to Cart'}
                 </button>
@@ -318,6 +329,10 @@ function App() {
         loadProducts()
     }, [])
 
+    useEffect(() => {
+        initCartButtonListener()
+    }, [])
+
     // Group products by category
     const productsByCategory = products.reduce((acc, product) => {
         const category = product.category
@@ -446,6 +461,9 @@ function App() {
             {/* Quick Navigation */}
             <QuickNavigation />
 
+            <CartDrawer />
+            <CartPage />
+
             {/* Analytics */}
             <Analytics />
             <SpeedInsights />
@@ -456,4 +474,8 @@ function App() {
 // Render the app
 const container = document.getElementById('root')
 const root = createRoot(container)
-root.render(<App />)
+root.render(
+    <CartProvider>
+        <App />
+    </CartProvider>
+)

--- a/src/components/CartDrawer.jsx
+++ b/src/components/CartDrawer.jsx
@@ -1,0 +1,139 @@
+import React, { useEffect, useRef } from 'react'
+import { useCart } from '../hooks/useCart'
+
+export default function CartDrawer() {
+    const { cart, isOpen, closeCart, openCartPage } = useCart()
+    const ref = useRef(null)
+
+    useEffect(() => {
+        const handleEsc = (e) => {
+            if (e.key === 'Escape') closeCart()
+        }
+        if (isOpen) document.addEventListener('keydown', handleEsc)
+        return () => document.removeEventListener('keydown', handleEsc)
+    }, [isOpen, closeCart])
+
+    useEffect(() => {
+        if (isOpen) {
+            ref.current?.focus()
+        }
+    }, [isOpen])
+
+    const itemCount = cart.items.reduce((sum, i) => sum + i.qty, 0)
+
+    return (
+        <div
+            className={`fixed inset-0 z-50 ${isOpen ? '' : 'pointer-events-none'}`}
+        >
+            <div
+                className={`absolute inset-0 bg-black/50 transition-opacity ${isOpen ? 'opacity-100' : 'opacity-0'}`}
+                onClick={closeCart}
+            />
+            <div
+                ref={ref}
+                tabIndex="-1"
+                className={`absolute right-0 top-0 h-full w-80 bg-white shadow-xl transition-transform dark:bg-gray-800 ${isOpen ? 'translate-x-0' : 'translate-x-full'}`}
+                role="dialog"
+                aria-modal="true"
+                aria-label="Shopping cart"
+            >
+                <div className="flex items-center justify-between border-b p-4">
+                    <h2 className="text-lg font-semibold">
+                        Cart ({itemCount})
+                    </h2>
+                    <button onClick={closeCart} aria-label="Close cart">
+                        ✕
+                    </button>
+                </div>
+                <div className="flex h-full flex-col justify-between">
+                    <ul className="flex-1 overflow-y-auto p-4">
+                        {cart.items.length === 0 && (
+                            <li className="text-center text-sm">
+                                Your cart is empty.
+                            </li>
+                        )}
+                        {cart.items.map((item) => (
+                            <li
+                                key={item.variantId}
+                                className="mb-4 flex items-center justify-between"
+                            >
+                                <div>
+                                    <p className="font-medium">{item.name}</p>
+                                    <p className="text-sm">
+                                        $
+                                        {(item.unitPrice * item.qty).toFixed(2)}
+                                    </p>
+                                </div>
+                                <div className="flex items-center gap-2">
+                                    <button
+                                        className="px-2"
+                                        onClick={() =>
+                                            window.dispatchEvent(
+                                                new CustomEvent('cart:update', {
+                                                    detail: {
+                                                        variantId:
+                                                            item.variantId,
+                                                        qty: item.qty - 1,
+                                                    },
+                                                })
+                                            )
+                                        }
+                                        aria-label={`Decrease quantity of ${item.name}`}
+                                    >
+                                        -
+                                    </button>
+                                    <span>{item.qty}</span>
+                                    <button
+                                        className="px-2"
+                                        onClick={() =>
+                                            window.dispatchEvent(
+                                                new CustomEvent('cart:update', {
+                                                    detail: {
+                                                        variantId:
+                                                            item.variantId,
+                                                        qty: item.qty + 1,
+                                                    },
+                                                })
+                                            )
+                                        }
+                                        aria-label={`Increase quantity of ${item.name}`}
+                                    >
+                                        +
+                                    </button>
+                                    <button
+                                        className="text-red-600"
+                                        onClick={() =>
+                                            window.dispatchEvent(
+                                                new CustomEvent('cart:remove', {
+                                                    detail: {
+                                                        variantId:
+                                                            item.variantId,
+                                                    },
+                                                })
+                                            )
+                                        }
+                                        aria-label={`Remove ${item.name}`}
+                                    >
+                                        Remove
+                                    </button>
+                                </div>
+                            </li>
+                        ))}
+                    </ul>
+                    <div className="border-t p-4">
+                        <div className="mb-2 flex justify-between">
+                            <span>Subtotal</span>
+                            <span>${cart.subtotal.toFixed(2)}</span>
+                        </div>
+                        <button
+                            className="w-full rounded bg-green-600 px-4 py-2 text-white hover:bg-green-700"
+                            onClick={openCartPage}
+                        >
+                            View Cart
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/src/components/CartPage.jsx
+++ b/src/components/CartPage.jsx
@@ -1,0 +1,94 @@
+import React from 'react'
+import { useCart } from '../hooks/useCart'
+
+export default function CartPage() {
+    const { cart, isPageOpen, closeCartPage } = useCart()
+
+    if (!isPageOpen) return null
+
+    return (
+        <div className="fixed inset-0 z-40 overflow-auto bg-white p-6 dark:bg-gray-900">
+            <div className="mb-4 flex items-center justify-between">
+                <h1 className="text-2xl font-bold">Shopping Cart</h1>
+                <button onClick={closeCartPage} aria-label="Close cart page">
+                    ✕
+                </button>
+            </div>
+            {cart.items.length === 0 ? (
+                <p>Your cart is empty.</p>
+            ) : (
+                <table className="w-full text-left">
+                    <thead>
+                        <tr>
+                            <th className="p-2">Product</th>
+                            <th className="p-2">Price</th>
+                            <th className="p-2">Qty</th>
+                            <th className="p-2">Total</th>
+                            <th className="p-2"></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {cart.items.map((item) => (
+                            <tr key={item.variantId} className="border-t">
+                                <td className="p-2">{item.name}</td>
+                                <td className="p-2">
+                                    ${item.unitPrice.toFixed(2)}
+                                </td>
+                                <td className="p-2">
+                                    <input
+                                        type="number"
+                                        min="1"
+                                        className="w-16 border p-1"
+                                        value={item.qty}
+                                        onChange={(e) =>
+                                            window.dispatchEvent(
+                                                new CustomEvent('cart:update', {
+                                                    detail: {
+                                                        variantId:
+                                                            item.variantId,
+                                                        qty: Number(
+                                                            e.target.value
+                                                        ),
+                                                    },
+                                                })
+                                            )
+                                        }
+                                        aria-label={`Quantity for ${item.name}`}
+                                    />
+                                </td>
+                                <td className="p-2">
+                                    ${(item.unitPrice * item.qty).toFixed(2)}
+                                </td>
+                                <td className="p-2">
+                                    <button
+                                        className="text-red-600"
+                                        onClick={() =>
+                                            window.dispatchEvent(
+                                                new CustomEvent('cart:remove', {
+                                                    detail: {
+                                                        variantId:
+                                                            item.variantId,
+                                                    },
+                                                })
+                                            )
+                                        }
+                                    >
+                                        Remove
+                                    </button>
+                                </td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            )}
+            <div className="mt-4 text-right">
+                <p className="text-lg">
+                    Subtotal:{' '}
+                    <span className="font-semibold">
+                        ${cart.subtotal.toFixed(2)}
+                    </span>
+                </p>
+            </div>
+        </div>
+    )
+}

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -2,11 +2,13 @@ import React, { useState, useEffect } from 'react'
 import LocalBusinessInfo from './LocalBusinessInfo'
 import SearchNavigation from './SearchNavigation'
 import { slugify } from '../utils/slugify'
+import { useCart } from '../hooks/useCart'
 
 function Navigation({ products = [] }) {
     const [isMenuOpen, setIsMenuOpen] = useState(false)
     const [isScrolled, setIsScrolled] = useState(false)
     const [activeSection, setActiveSection] = useState('home')
+    const { cart, openCart } = useCart()
 
     // Handle scroll effects
     useEffect(() => {
@@ -237,6 +239,26 @@ function Navigation({ products = [] }) {
                                     (573) 677-6418
                                 </a>
                             </div>
+
+                            {/* Cart Button */}
+                            <button
+                                onClick={openCart}
+                                aria-label="Open cart"
+                                className="relative rounded p-2 text-gray-700 hover:text-green-600 dark:text-gray-300 dark:hover:text-green-400"
+                            >
+                                <i
+                                    className="fas fa-shopping-cart"
+                                    aria-hidden="true"
+                                />
+                                {cart.items.length > 0 && (
+                                    <span className="absolute -right-1 -top-1 rounded-full bg-red-600 px-1 text-xs text-white">
+                                        {cart.items.reduce(
+                                            (sum, i) => sum + i.qty,
+                                            0
+                                        )}
+                                    </span>
+                                )}
+                            </button>
 
                             {/* Mobile menu button */}
                             <button

--- a/src/hooks/useCart.jsx
+++ b/src/hooks/useCart.jsx
@@ -1,0 +1,139 @@
+import React, {
+    createContext,
+    useContext,
+    useEffect,
+    useState,
+    useCallback,
+} from 'react'
+
+const CartContext = createContext()
+
+function getInitialCart() {
+    try {
+        const stored = localStorage.getItem('cart')
+        return stored
+            ? JSON.parse(stored)
+            : { items: [], subtotal: 0, total: 0 }
+    } catch {
+        return { items: [], subtotal: 0, total: 0 }
+    }
+}
+
+export function CartProvider({ children }) {
+    const [cart, setCart] = useState(getInitialCart)
+    const [isOpen, setIsOpen] = useState(false)
+    const [isPageOpen, setIsPageOpen] = useState(false)
+
+    const recalc = (items) => {
+        const subtotal = items.reduce(
+            (sum, item) => sum + item.unitPrice * item.qty,
+            0
+        )
+        return { items, subtotal, total: subtotal }
+    }
+
+    const persist = (data) => {
+        setCart(data)
+        try {
+            localStorage.setItem('cart', JSON.stringify(data))
+        } catch {
+            /* ignore */
+        }
+    }
+
+    const addItem = useCallback((item) => {
+        setCart((prev) => {
+            const existing = prev.items.find(
+                (i) => i.variantId === item.variantId
+            )
+            let items
+            if (existing) {
+                items = prev.items.map((i) =>
+                    i.variantId === item.variantId
+                        ? { ...i, qty: i.qty + item.qty }
+                        : i
+                )
+            } else {
+                items = [...prev.items, item]
+            }
+            const updated = recalc(items)
+            persist(updated)
+            return updated
+        })
+    }, [])
+
+    const updateItem = useCallback((variantId, qty) => {
+        setCart((prev) => {
+            const items = prev.items
+                .map((i) => (i.variantId === variantId ? { ...i, qty } : i))
+                .filter((i) => i.qty > 0)
+            const updated = recalc(items)
+            persist(updated)
+            return updated
+        })
+    }, [])
+
+    const removeItem = useCallback((variantId) => {
+        setCart((prev) => {
+            const items = prev.items.filter((i) => i.variantId !== variantId)
+            const updated = recalc(items)
+            persist(updated)
+            return updated
+        })
+    }, [])
+
+    const clearCart = useCallback(() => {
+        const empty = recalc([])
+        persist(empty)
+    }, [])
+
+    useEffect(() => {
+        const handleAdd = (e) => {
+            addItem(e.detail)
+            setIsOpen(true)
+        }
+        const handleUpdate = (e) => updateItem(e.detail.variantId, e.detail.qty)
+        const handleRemove = (e) => removeItem(e.detail.variantId)
+        const handleClear = () => clearCart()
+
+        window.addEventListener('cart:add', handleAdd)
+        window.addEventListener('cart:update', handleUpdate)
+        window.addEventListener('cart:remove', handleRemove)
+        window.addEventListener('cart:clear', handleClear)
+        return () => {
+            window.removeEventListener('cart:add', handleAdd)
+            window.removeEventListener('cart:update', handleUpdate)
+            window.removeEventListener('cart:remove', handleRemove)
+            window.removeEventListener('cart:clear', handleClear)
+        }
+    }, [addItem, updateItem, removeItem, clearCart])
+
+    const openCart = () => setIsOpen(true)
+    const closeCart = () => setIsOpen(false)
+    const openCartPage = () => setIsPageOpen(true)
+    const closeCartPage = () => setIsPageOpen(false)
+
+    return (
+        <CartContext.Provider
+            value={{
+                cart,
+                addItem,
+                updateItem,
+                removeItem,
+                clearCart,
+                isOpen,
+                openCart,
+                closeCart,
+                isPageOpen,
+                openCartPage,
+                closeCartPage,
+            }}
+        >
+            {children}
+        </CartContext.Provider>
+    )
+}
+
+export function useCart() {
+    return useContext(CartContext)
+}

--- a/src/utils/cartEvents.js
+++ b/src/utils/cartEvents.js
@@ -1,0 +1,16 @@
+export function initCartButtonListener() {
+    document.addEventListener('click', (e) => {
+        const btn = e.target.closest('.add-to-cart')
+        if (!btn) return
+        const detail = {
+            productId: btn.dataset.productId,
+            variantId: btn.dataset.variantId,
+            name: btn.dataset.name,
+            image: btn.dataset.image,
+            unitPrice: parseFloat(btn.dataset.price),
+            currency: btn.dataset.currency,
+            qty: 1,
+        }
+        window.dispatchEvent(new CustomEvent('cart:add', { detail }))
+    })
+}


### PR DESCRIPTION
## Summary
- add cart provider with localStorage persistence and event listeners
- introduce mini cart drawer and full cart page components
- wire product buttons and navigation icon to cart events

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a5f3dae988329a06ba54c06ed8536