### PR TITLE
feat: add standalone cart page

### DIFF
--- a/app.jsx
+++ b/app.jsx
@@ -462,7 +462,6 @@ function App() {
             <QuickNavigation />
 
             <CartDrawer />
-            <CartPage />
 
             {/* Analytics */}
             <Analytics />
@@ -471,11 +470,12 @@ function App() {
     )
 }
 
-// Render the app
+// Render the app or cart page based on current path
 const container = document.getElementById('root')
 const root = createRoot(container)
+
 root.render(
     <CartProvider>
-        <App />
+        {window.location.pathname === '/cart' ? <CartPage /> : <App />}
     </CartProvider>
 )

--- a/src/components/CartDrawer.jsx
+++ b/src/components/CartDrawer.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react'
 import { useCart } from '../hooks/useCart'
 
 export default function CartDrawer() {
-    const { cart, isOpen, closeCart, openCartPage } = useCart()
+    const { cart, isOpen, closeCart } = useCart()
     const ref = useRef(null)
 
     useEffect(() => {
@@ -127,7 +127,10 @@ export default function CartDrawer() {
                         </div>
                         <button
                             className="w-full rounded bg-green-600 px-4 py-2 text-white hover:bg-green-700"
-                            onClick={openCartPage}
+                            onClick={() => {
+                                closeCart()
+                                window.location.href = '/cart'
+                            }}
                         >
                             View Cart
                         </button>

--- a/src/components/CartPage.jsx
+++ b/src/components/CartPage.jsx
@@ -2,85 +2,76 @@ import React from 'react'
 import { useCart } from '../hooks/useCart'
 
 export default function CartPage() {
-    const { cart, isPageOpen, closeCartPage } = useCart()
+    const { cart } = useCart()
 
-    if (!isPageOpen) return null
+    const handleQty = (variantId, qty) => {
+        window.dispatchEvent(
+            new CustomEvent('cart:update', {
+                detail: { variantId, qty: Number(qty) },
+            })
+        )
+    }
+
+    const handleRemove = (variantId) => {
+        window.dispatchEvent(
+            new CustomEvent('cart:remove', { detail: { variantId } })
+        )
+    }
+
+    const itemCount = cart.items.length
+
+    if (itemCount === 0) {
+        return (
+            <div className="mx-auto max-w-3xl p-6">
+                <h1 className="mb-4 text-2xl font-bold">Your cart</h1>
+                <p>Your cart is empty.</p>
+                <a href="/" className="text-green-600 underline">
+                    Continue shopping
+                </a>
+            </div>
+        )
+    }
 
     return (
-        <div className="fixed inset-0 z-40 overflow-auto bg-white p-6 dark:bg-gray-900">
-            <div className="mb-4 flex items-center justify-between">
-                <h1 className="text-2xl font-bold">Shopping Cart</h1>
-                <button onClick={closeCartPage} aria-label="Close cart page">
-                    ✕
-                </button>
-            </div>
-            {cart.items.length === 0 ? (
-                <p>Your cart is empty.</p>
-            ) : (
-                <table className="w-full text-left">
-                    <thead>
-                        <tr>
-                            <th className="p-2">Product</th>
-                            <th className="p-2">Price</th>
-                            <th className="p-2">Qty</th>
-                            <th className="p-2">Total</th>
-                            <th className="p-2"></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {cart.items.map((item) => (
-                            <tr key={item.variantId} className="border-t">
-                                <td className="p-2">{item.name}</td>
-                                <td className="p-2">
-                                    ${item.unitPrice.toFixed(2)}
-                                </td>
-                                <td className="p-2">
-                                    <input
-                                        type="number"
-                                        min="1"
-                                        className="w-16 border p-1"
-                                        value={item.qty}
-                                        onChange={(e) =>
-                                            window.dispatchEvent(
-                                                new CustomEvent('cart:update', {
-                                                    detail: {
-                                                        variantId:
-                                                            item.variantId,
-                                                        qty: Number(
-                                                            e.target.value
-                                                        ),
-                                                    },
-                                                })
-                                            )
-                                        }
-                                        aria-label={`Quantity for ${item.name}`}
-                                    />
-                                </td>
-                                <td className="p-2">
-                                    ${(item.unitPrice * item.qty).toFixed(2)}
-                                </td>
-                                <td className="p-2">
-                                    <button
-                                        className="text-red-600"
-                                        onClick={() =>
-                                            window.dispatchEvent(
-                                                new CustomEvent('cart:remove', {
-                                                    detail: {
-                                                        variantId:
-                                                            item.variantId,
-                                                    },
-                                                })
-                                            )
-                                        }
-                                    >
-                                        Remove
-                                    </button>
-                                </td>
-                            </tr>
-                        ))}
-                    </tbody>
-                </table>
-            )}
+        <div className="mx-auto max-w-3xl p-6">
+            <h1 className="mb-4 text-2xl font-bold">Your cart ({itemCount})</h1>
+            <ul className="divide-y">
+                {cart.items.map((item) => (
+                    <li
+                        key={item.variantId}
+                        className="flex items-center justify-between py-4"
+                    >
+                        <div>
+                            <p className="font-medium">{item.name}</p>
+                            <p className="text-sm">
+                                ${item.unitPrice.toFixed(2)}
+                            </p>
+                        </div>
+                        <div className="flex items-center gap-2">
+                            <input
+                                type="number"
+                                min="1"
+                                className="w-16 border p-1"
+                                value={item.qty}
+                                onChange={(e) =>
+                                    handleQty(item.variantId, e.target.value)
+                                }
+                                aria-label={`Quantity for ${item.name}`}
+                            />
+                            <span className="w-20 text-right">
+                                ${(item.unitPrice * item.qty).toFixed(2)}
+                            </span>
+                            <button
+                                className="text-red-600"
+                                onClick={() => handleRemove(item.variantId)}
+                                aria-label={`Remove ${item.name}`}
+                            >
+                                Remove
+                            </button>
+                        </div>
+                    </li>
+                ))}
+            </ul>
             <div className="mt-4 text-right">
                 <p className="text-lg">
                     Subtotal:{' '}
@@ -88,6 +79,9 @@ export default function CartPage() {
                         ${cart.subtotal.toFixed(2)}
                     </span>
                 </p>
+                <button className="mt-4 rounded bg-green-600 px-4 py-2 text-white hover:bg-green-700">
+                    Proceed to checkout
+                </button>
             </div>
         </div>
     )

--- a/src/hooks/useCart.jsx
+++ b/src/hooks/useCart.jsx
@@ -22,7 +22,6 @@ function getInitialCart() {
 export function CartProvider({ children }) {
     const [cart, setCart] = useState(getInitialCart)
     const [isOpen, setIsOpen] = useState(false)
-    const [isPageOpen, setIsPageOpen] = useState(false)
 
     const recalc = (items) => {
         const subtotal = items.reduce(
@@ -110,8 +109,6 @@ export function CartProvider({ children }) {
 
     const openCart = () => setIsOpen(true)
     const closeCart = () => setIsOpen(false)
-    const openCartPage = () => setIsPageOpen(true)
-    const closeCartPage = () => setIsPageOpen(false)
 
     return (
         <CartContext.Provider
@@ -124,9 +121,6 @@ export function CartProvider({ children }) {
                 isOpen,
                 openCart,
                 closeCart,
-                isPageOpen,
-                openCartPage,
-                closeCartPage,
             }}
         >
             {children}


### PR DESCRIPTION
## Summary
- add dedicated cart page rendered on `/cart`
- update cart drawer to link to new page
- simplify cart context by removing unused page state

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a6a1237008329a317f77516967c67