### PR TITLE
feat: enable cart page routing

### DIFF
--- a/src/components/CartDrawer.jsx
+++ b/src/components/CartDrawer.jsx
@@ -125,12 +125,16 @@ export default function CartDrawer() {
                             <span>Subtotal</span>
                             <span>${cart.subtotal.toFixed(2)}</span>
                         </div>
-                        <button
-                            className="w-full rounded bg-green-600 px-4 py-2 text-white hover:bg-green-700"
-                            onClick={openCartPage}
+                        <a
+                            href="/cart"
+                            onClick={(e) => {
+                                e.preventDefault()
+                                openCartPage()
+                            }}
+                            className="block w-full rounded bg-green-600 px-4 py-2 text-center text-white hover:bg-green-700"
                         >
                             View Cart
-                        </button>
+                        </a>
                     </div>
                 </div>
             </div>

--- a/src/hooks/useCart.jsx
+++ b/src/hooks/useCart.jsx
@@ -110,8 +110,30 @@ export function CartProvider({ children }) {
 
     const openCart = () => setIsOpen(true)
     const closeCart = () => setIsOpen(false)
-    const openCartPage = () => setIsPageOpen(true)
-    const closeCartPage = () => setIsPageOpen(false)
+
+    const openCartPage = () => {
+        setIsOpen(false)
+        setIsPageOpen(true)
+        window.history.pushState({}, '', '/cart')
+    }
+
+    const closeCartPage = () => {
+        setIsPageOpen(false)
+        if (window.location.pathname === '/cart') {
+            window.history.back()
+        }
+    }
+
+    useEffect(() => {
+        const handleRoute = () => {
+            const isCart = window.location.pathname === '/cart'
+            setIsPageOpen(isCart)
+            if (isCart) setIsOpen(false)
+        }
+        window.addEventListener('popstate', handleRoute)
+        handleRoute()
+        return () => window.removeEventListener('popstate', handleRoute)
+    }, [])
 
     return (
         <CartContext.Provider


### PR DESCRIPTION
## Summary
- route "/cart" into cart context state with history syncing
- link mini-cart "View Cart" action to the full cart page

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a6a1237008329a317f77516967c67