### PR TITLE
feat: add auto contrast utility

### DIFF
--- a/app.jsx
+++ b/app.jsx
@@ -17,6 +17,7 @@ import CartDrawer from './src/components/CartDrawer'
 import CartPage from './src/components/CartPage'
 import { CartProvider } from './src/hooks/useCart'
 import { initCartButtonListener } from './src/utils/cartEvents'
+import { applyAutoContrast } from './src/utils/autoContrast'
 
 // Import hooks
 import { useNavigation, useKeyboardNavigation } from './src/hooks/useNavigation'
@@ -48,7 +49,7 @@ function ProductCard({ product }) {
             {/* Product Banner */}
             {product.banner && (
                 <div
-                    className={`product-banner ${
+                    className={`product-banner auto-contrast ${
                         product.banner === 'New'
                             ? 'bg-green-600'
                             : product.banner === 'Out of Stock'
@@ -332,6 +333,10 @@ function App() {
     useEffect(() => {
         initCartButtonListener()
     }, [])
+
+    useEffect(() => {
+        applyAutoContrast()
+    }, [products])
 
     // Group products by category
     const productsByCategory = products.reduce((acc, product) => {

--- a/src/utils/autoContrast.js
+++ b/src/utils/autoContrast.js
@@ -1,0 +1,43 @@
+export function wcagContrastColor(bg) {
+    const [r, g, b] = bg.match(/\d+/g).map(Number)
+    const L = (v) => {
+        v /= 255
+        return v <= 0.03928 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4
+    }
+    const luminance = 0.2126 * L(r) + 0.7152 * L(g) + 0.0722 * L(b)
+
+    const contrast = (L1, L2) => {
+        const bright = Math.max(L1, L2) + 0.05
+        const dark = Math.min(L1, L2) + 0.05
+        return bright / dark
+    }
+
+    const whiteContrast = contrast(luminance, 1)
+    const blackContrast = contrast(luminance, 0)
+
+    if (whiteContrast >= 4.5 && whiteContrast > blackContrast) return '#fff'
+    if (blackContrast >= 4.5 && blackContrast >= whiteContrast) return '#111'
+
+    let [cr, cg, cb] =
+        whiteContrast > blackContrast ? [255, 255, 255] : [17, 17, 17]
+    const step = whiteContrast > blackContrast ? -1 : 1
+    while (
+        contrast(luminance, 0.2126 * L(cr) + 0.7152 * L(cg) + 0.0722 * L(cb)) <
+        4.5
+    ) {
+        cr = Math.min(255, Math.max(0, cr + step))
+        cg = Math.min(255, Math.max(0, cg + step))
+        cb = Math.min(255, Math.max(0, cb + step))
+    }
+    return `rgb(${cr},${cg},${cb})`
+}
+
+export function applyAutoContrast(root = document) {
+    root.querySelectorAll('.auto-contrast').forEach((el) => {
+        let bg = getComputedStyle(el).backgroundColor
+        if (bg === 'rgba(0, 0, 0, 0)' || bg === 'transparent') {
+            bg = getComputedStyle(el.parentElement).backgroundColor
+        }
+        el.style.color = wcagContrastColor(bg)
+    })
+}


### PR DESCRIPTION
## Summary
- add `wcagContrastColor` and `applyAutoContrast` helpers
- use auto-contrast on product banners and invoke after product load

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ade8f02348329b53808077c4514ac