### PR TITLE
feat: redesign cart page

### DIFF
--- a/src/components/CartPage.jsx
+++ b/src/components/CartPage.jsx
@@ -6,39 +6,62 @@ export default function CartPage() {
 
     if (!isPageOpen) return null
 
+    const itemCount = cart.items.reduce((sum, item) => sum + item.qty, 0)
+
     return (
-        <div className="fixed inset-0 z-40 overflow-auto bg-white p-6 dark:bg-gray-900">
-            <div className="mb-4 flex items-center justify-between">
-                <h1 className=" auto-contrast text-2xl font-bold">Shopping Cart</h1>
-                <button onClick={closeCartPage} aria-label="Close cart page">
-                    ✕
-                </button>
-            </div>
-            {cart.items.length === 0 ? (
-                <p>Your cart is empty.</p>
-            ) : (
-                <table className="auto-contrast w-full text-left">
-                    <thead>
-                        <tr>
-                            <th className="p-2">Product</th>
-                            <th className="p-2">Price</th>
-                            <th className="p-2">Qty</th>
-                            <th className="p-2">Total</th>
-                            <th className="p-2"></th>
-                        </tr>
-                    </thead>
-                    <tbody>
+        <div className="fixed inset-0 z-40 overflow-auto bg-white dark:bg-gray-900">
+            <div className="mx-auto max-w-3xl p-6">
+                <div className="mb-6 flex items-center justify-between border-b pb-4">
+                    <h1 className="auto-contrast text-2xl font-bold">
+                        Your Cart ({itemCount})
+                    </h1>
+                    <button
+                        onClick={closeCartPage}
+                        aria-label="Close cart page"
+                        className="auto-contrast rounded p-2 hover:bg-gray-200 dark:hover:bg-gray-700"
+                    >
+                        ✕
+                    </button>
+                </div>
+                {cart.items.length === 0 ? (
+                    <p className="auto-contrast">Your cart is empty.</p>
+                ) : (
+                    <ul className="divide-y">
                         {cart.items.map((item) => (
-                            <tr key={item.variantId} className="border-t">
-                                <td className="p-2">{item.name}</td>
-                                <td className="p-2">
-                                    ${item.unitPrice.toFixed(2)}
-                                </td>
-                                <td className="p-2">
+                            <li
+                                key={item.variantId}
+                                className="flex flex-col gap-2 py-4 sm:flex-row sm:items-center sm:justify-between"
+                            >
+                                <div className="flex-1">
+                                    <p className="auto-contrast font-medium">
+                                        {item.name}
+                                    </p>
+                                    <p className="auto-contrast text-sm">
+                                        ${item.unitPrice.toFixed(2)} each
+                                    </p>
+                                </div>
+                                <div className="flex items-center gap-2">
+                                    <button
+                                        className="px-2"
+                                        onClick={() =>
+                                            window.dispatchEvent(
+                                                new CustomEvent('cart:update', {
+                                                    detail: {
+                                                        variantId:
+                                                            item.variantId,
+                                                        qty: item.qty - 1,
+                                                    },
+                                                })
+                                            )
+                                        }
+                                        aria-label={`Decrease quantity of ${item.name}`}
+                                    >
+                                        -
+                                    </button>
                                     <input
                                         type="number"
                                         min="1"
-                                        className="w-16 border p-1"
+                                        className="w-16 border p-1 text-center"
                                         value={item.qty}
                                         onChange={(e) =>
                                             window.dispatchEvent(
@@ -55,13 +78,31 @@ export default function CartPage() {
                                         }
                                         aria-label={`Quantity for ${item.name}`}
                                     />
-                                </td>
-                                <td className="p-2">
-                                    ${(item.unitPrice * item.qty).toFixed(2)}
-                                </td>
-                                <td className="p-2">
                                     <button
-                                        className="text-red-600"
+                                        className="px-2"
+                                        onClick={() =>
+                                            window.dispatchEvent(
+                                                new CustomEvent('cart:update', {
+                                                    detail: {
+                                                        variantId:
+                                                            item.variantId,
+                                                        qty: item.qty + 1,
+                                                    },
+                                                })
+                                            )
+                                        }
+                                        aria-label={`Increase quantity of ${item.name}`}
+                                    >
+                                        +
+                                    </button>
+                                </div>
+                                <div className="text-right sm:w-24">
+                                    <p className="auto-contrast">
+                                        $
+                                        {(item.unitPrice * item.qty).toFixed(2)}
+                                    </p>
+                                    <button
+                                        className="text-sm text-red-600"
                                         onClick={() =>
                                             window.dispatchEvent(
                                                 new CustomEvent('cart:remove', {
@@ -72,22 +113,36 @@ export default function CartPage() {
                                                 })
                                             )
                                         }
+                                        aria-label={`Remove ${item.name}`}
                                     >
                                         Remove
                                     </button>
-                                </td>
-                            </tr>
+                                </div>
+                            </li>
                         ))}
-                    </tbody>
-                </table>
-            )}
-            <div className="mt-4 text-right">
-                <p className="text-lg">
-                    Subtotal:{' '}
-                    <span className="font-semibold">
-                        ${cart.subtotal.toFixed(2)}
-                    </span>
-                </p>
+                    </ul>
+                )}
+                {cart.items.length > 0 && (
+                    <div className="mt-6 border-t pt-4">
+                        <div className="mb-4 flex justify-between text-lg">
+                            <span className="auto-contrast">Subtotal</span>
+                            <span className="auto-contrast font-semibold">
+                                ${cart.subtotal.toFixed(2)}
+                            </span>
+                        </div>
+                        <div className="flex justify-end gap-4">
+                            <button
+                                onClick={closeCartPage}
+                                className="auto-contrast rounded border px-4 py-2 hover:bg-gray-100 dark:border-gray-700 dark:hover:bg-gray-800"
+                            >
+                                Continue shopping
+                            </button>
+                            <button className="rounded bg-green-600 px-4 py-2 text-white hover:bg-green-700">
+                                Checkout
+                            </button>
+                        </div>
+                    </div>
+                )}
             </div>
         </div>
     )

--- a/src/components/CartPage.jsx
+++ b/src/components/CartPage.jsx
@@ -10,7 +10,7 @@ export default function CartPage() {
 
     return (
         <div className="fixed inset-0 z-40 overflow-auto bg-white dark:bg-gray-900">
-            <div className="mx-auto max-w-3xl p-6">
+            <div className="mx-auto mt-16 max-w-3xl p-6">
                 <div className="mb-6 flex items-center justify-between border-b pb-4">
                     <h1 className="auto-contrast text-2xl font-bold">
                         Your Cart ({itemCount})
@@ -122,27 +122,31 @@ export default function CartPage() {
                         ))}
                     </ul>
                 )}
-                {cart.items.length > 0 && (
-                    <div className="mt-6 border-t pt-4">
+                <div
+                    className={`mt-6 ${cart.items.length > 0 ? 'border-t pt-4' : ''}`}
+                >
+                    {cart.items.length > 0 && (
                         <div className="mb-4 flex justify-between text-lg">
                             <span className="auto-contrast">Subtotal</span>
                             <span className="auto-contrast font-semibold">
                                 ${cart.subtotal.toFixed(2)}
                             </span>
                         </div>
-                        <div className="flex justify-end gap-4">
-                            <button
-                                onClick={closeCartPage}
-                                className="auto-contrast rounded border px-4 py-2 hover:bg-gray-100 dark:border-gray-700 dark:hover:bg-gray-800"
-                            >
-                                Continue shopping
-                            </button>
+                    )}
+                    <div className="flex justify-end gap-4">
+                        <button
+                            onClick={closeCartPage}
+                            className="auto-contrast rounded border px-4 py-2 hover:bg-gray-100 dark:border-gray-700 dark:hover:bg-gray-800"
+                        >
+                            Continue shopping
+                        </button>
+                        {cart.items.length > 0 && (
                             <button className="rounded bg-green-600 px-4 py-2 text-white hover:bg-green-700">
                                 Checkout
                             </button>
-                        </div>
+                        )}
                     </div>
-                )}
+                </div>
             </div>
         </div>
     )

--- a/src/hooks/useCart.jsx
+++ b/src/hooks/useCart.jsx
@@ -110,8 +110,14 @@ export function CartProvider({ children }) {
 
     const openCart = () => setIsOpen(true)
     const closeCart = () => setIsOpen(false)
-    const openCartPage = () => setIsPageOpen(true)
-    const closeCartPage = () => setIsPageOpen(false)
+    const openCartPage = () => {
+        setIsOpen(false)
+        setIsPageOpen(true)
+    }
+    const closeCartPage = () => {
+        setIsPageOpen(false)
+        setIsOpen(false)
+    }
 
     return (
         <CartContext.Provider


### PR DESCRIPTION
## Summary
- close cart drawer when viewing cart page
- ensure close button hides cart page and drawer
- redesign cart page with responsive layout and checkout summary

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e673f9c888329b4a4fd57535a3a0e