### PR TITLE
fix: align button accessible names with visible text

### DIFF
--- a/app.jsx
+++ b/app.jsx
@@ -119,7 +119,11 @@ function ProductCard({ product }) {
                             : 'bg-emerald-700 text-white transition-colors hover:bg-white hover:text-green-600 focus:outline-green-500 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 active:bg-emerald-600 active:text-white'
                     }`}
                     disabled={isOutOfStock}
-                    aria-label={`Add ${product.name} to cart`}
+                    aria-label={
+                        isOutOfStock
+                            ? `Out of Stock ${product.name}`
+                            : `Add to Cart ${product.name}`
+                    }
                     data-product-id={slugify(product.name)}
                     data-variant-id={`${slugify(product.name)}_${slugify(selectedSize)}`}
                     data-name={product.name}

--- a/src/components/CartDrawer.jsx
+++ b/src/components/CartDrawer.jsx
@@ -59,7 +59,7 @@ export default function CartDrawer() {
                         aria-label="Close cart"
                         className="auto-contrast hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
                     >
-                        ✕
+                        <span aria-hidden="true">✕</span>
                     </button>
                 </div>
                 <div className="flex h-full flex-col justify-between">
@@ -97,7 +97,7 @@ export default function CartDrawer() {
                                         }
                                         aria-label={`Decrease quantity of ${item.name}`}
                                     >
-                                        -
+                                        <span aria-hidden="true">-</span>
                                     </button>
                                     <span className="text-gray-900 dark:text-white">{item.qty}</span>
                                     <button
@@ -115,7 +115,7 @@ export default function CartDrawer() {
                                         }
                                         aria-label={`Increase quantity of ${item.name}`}
                                     >
-                                        +
+                                        <span aria-hidden="true">+</span>
                                     </button>
                                     <button
                                         className="text-red-600"

--- a/src/components/CartPage.jsx
+++ b/src/components/CartPage.jsx
@@ -37,7 +37,7 @@ export default function CartPage() {
                         className="rounded-xl border border-slate-300 p-2 focus:outline-none focus:ring-2 focus:ring-emerald-700 focus:ring-offset-2 dark:border-gray-600"
                         aria-label="Close cart"
                     >
-                        ✕
+                        <span aria-hidden="true">✕</span>
                     </button>
                 </div>
                 {cart.items.length === 0 ? (
@@ -85,7 +85,6 @@ export default function CartPage() {
                         </div>
                         <button
                             className="inline-flex w-full items-center justify-center rounded-2xl bg-emerald-700 px-5 py-3 font-semibold text-white shadow hover:bg-emerald-800 focus:outline-none focus:ring-2 focus:ring-emerald-700 focus:ring-offset-2"
-                            aria-label="Proceed to checkout"
                         >
                             Checkout
                         </button>

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -347,10 +347,9 @@ function Navigation({ products = [] }) {
                                 onClick={toggleMenu}
                                 aria-expanded={isMenuOpen}
                                 aria-controls="mobile-menu"
-                                aria-label="Toggle navigation menu"
                                 className="inline-flex items-center justify-center rounded-md p-2 text-gray-700 hover:bg-green-50 hover:text-green-600 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-green-500 md:hidden dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-green-400"
                             >
-                                <span className="sr-only">Open main menu</span>
+                                <span className="sr-only">{isMenuOpen ? 'Close main menu' : 'Open main menu'}</span>
                                 <i
                                     className={`fas ${isMenuOpen ? 'fa-times' : 'fa-bars'} text-xl`}
                                     aria-hidden="true"

--- a/src/components/SearchNavigation.jsx
+++ b/src/components/SearchNavigation.jsx
@@ -185,6 +185,7 @@ function SearchNavigation({ products = [] }) {
                                 <button
                                     onClick={() => setIsOpen(false)}
                                     className="absolute right-3 top-1/2 -translate-y-1/2 transform text-gray-400 hover:text-gray-600"
+                                    aria-label="Close search"
                                 >
                                     <i
                                         className="fas fa-times"


### PR DESCRIPTION
## Summary
- ensure add-to-cart buttons include visible text in aria labels
- hide decorative symbols and add missing labels to navigation and cart controls
- support screen readers with dynamic mobile menu labels

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a298f775848329bd60fa999c5f8b7d