### PR TITLE
fix: include visible text in button names

### DIFF
--- a/src/components/CartDrawer.jsx
+++ b/src/components/CartDrawer.jsx
@@ -56,10 +56,10 @@ export default function CartDrawer() {
                     </h2>
                     <button
                         onClick={closeCart}
-                        aria-label="Close cart"
                         className="auto-contrast hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
                     >
-                        ✕
+                        <span aria-hidden="true">✕</span>
+                        <span className="sr-only">Close cart</span>
                     </button>
                 </div>
                 <div className="flex h-full flex-col justify-between">
@@ -97,7 +97,7 @@ export default function CartDrawer() {
                                         }
                                         aria-label={`Decrease quantity of ${item.name}`}
                                     >
-                                        -
+                                        <span aria-hidden="true">-</span>
                                     </button>
                                     <span className="text-gray-900 dark:text-white">{item.qty}</span>
                                     <button
@@ -115,7 +115,7 @@ export default function CartDrawer() {
                                         }
                                         aria-label={`Increase quantity of ${item.name}`}
                                     >
-                                        +
+                                        <span aria-hidden="true">+</span>
                                     </button>
                                     <button
                                         className="text-red-600"

--- a/src/components/CartPage.jsx
+++ b/src/components/CartPage.jsx
@@ -35,9 +35,9 @@ export default function CartPage() {
                     <button
                         onClick={closeCartPage}
                         className="rounded-xl border border-slate-300 p-2 focus:outline-none focus:ring-2 focus:ring-emerald-700 focus:ring-offset-2 dark:border-gray-600"
-                        aria-label="Close cart"
                     >
-                        ✕
+                        <span aria-hidden="true">✕</span>
+                        <span className="sr-only">Close cart</span>
                     </button>
                 </div>
                 {cart.items.length === 0 ? (

--- a/src/components/SearchNavigation.jsx
+++ b/src/components/SearchNavigation.jsx
@@ -186,6 +186,7 @@ function SearchNavigation({ products = [] }) {
                                     onClick={() => setIsOpen(false)}
                                     className="absolute right-3 top-1/2 -translate-y-1/2 transform text-gray-400 hover:text-gray-600"
                                 >
+                                    <span className="sr-only">Close search</span>
                                     <i
                                         className="fas fa-times"
                                         aria-hidden="true"


### PR DESCRIPTION
## Summary
- improve accessibility for search overlay close button
- add screen reader labels for cart buttons
- hide decorative symbols on cart quantity controls

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a298f775848329bd60fa999c5f8b7d