### PR TITLE
chore: add canonical links to static pages

### DIFF
--- a/cookie-policy.html
+++ b/cookie-policy.html
@@ -16,6 +16,7 @@
         
         <title>Cookie Policy - Route 66 Hemp</title>
         <link href="src/style.css" rel="stylesheet">
+        <link rel="canonical" href="https://route66hemp.com/cookie-policy/" />
     </head>
     <body class="bg-white text-gray-800 dark:bg-gray-900 dark:text-white">
         <main class="mx-auto max-w-4xl p-4">

--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
             content="mqIi89j9X4pKNYgBOCXypnGvacxtNjcM9a44yCXSrh0"
         >
 
-        <link rel="canonical" href="https://route66hemp.com" >
+        <link rel="canonical" href="https://route66hemp.com/" >
 
         <meta name="author" content="Christopher Gibbons" >
         <meta

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -15,6 +15,7 @@
         
         <title>Privacy Policy - Route 66 Hemp</title>
         <link href="src/style.css" rel="stylesheet">
+        <link rel="canonical" href="https://route66hemp.com/privacy-policy/" />
     </head>
     <body class="bg-white text-gray-800 dark:bg-gray-900 dark:text-white">
         <main class="mx-auto max-w-4xl p-4">

--- a/terms-of-service.html
+++ b/terms-of-service.html
@@ -16,6 +16,7 @@
         
         <title>Terms of Service - Route 66 Hemp</title>
         <link href="src/style.css" rel="stylesheet">
+        <link rel="canonical" href="https://route66hemp.com/terms-of-service/" />
     </head>
     <body class="bg-white text-gray-800 dark:bg-gray-900 dark:text-white">
         <main class="mx-auto max-w-4xl p-4">


### PR DESCRIPTION
## Summary
- add canonical tags to static HTML pages to clarify authoritative URLs

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aae2caa9448329a2a742b639ab5fbd