### PR TITLE
Fix Font Awesome icon rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,13 @@
         <!-- GA is now loaded via consent helper (analytics-consent.js) -->
 
         <link href="/src/style.css" rel="stylesheet">
+        <link
+            rel="stylesheet"
+            href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css"
+            integrity="sha512-dymDY0r1EnWV9vywgq6Z9erjRzCQXDpUe1koRaSPBb6e7iT730GUNShUMpOWcZH/5LiCFYl8/9gqS3bELVd3Bw=="
+            crossorigin="anonymous"
+            referrerpolicy="no-referrer"
+        />
         <meta
             name="description"
             content="Route 66 Hemp - Premium hemp products in St Robert, MO. Serving Pulaski County with quality THCa flower, concentrates, and vapes. Located near Fort Leonard Wood."


### PR DESCRIPTION
## Summary
- include the Font Awesome 5 CDN stylesheet in the HTML shell so legacy `<i>` icons render correctly

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8b5f59f848329873e0188b23c96fc