### PR TITLE
perf: reduce main bundle size

### DIFF
--- a/app.jsx
+++ b/app.jsx
@@ -1,13 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import { Analytics } from '@vercel/analytics/react'
-import { SpeedInsights } from '@vercel/speed-insights/react'
-import StructuredData from './src/components/StructuredData.jsx'
-import LocalBusinessInfo from './src/components/LocalBusinessInfo.jsx'
-import LocationContent from './src/components/LocationContent.jsx'
-import GoogleBusinessIntegration from './src/components/GoogleBusinessIntegration.jsx'
-import LocalSEOFAQ from './src/components/LocalSEOFAQ.jsx'
-import { businessInfo } from './src/utils/seoHelpers.js'
+import { businessInfo } from './src/utils/businessInfo.js'
 import AgeGate from './src/components/AgeGate.jsx'
 // Font Awesome (SVG) – import only what we use
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -28,8 +21,45 @@ import {
     faYoutube,
 } from '@fortawesome/free-brands-svg-icons'
 
+const StructuredData = React.lazy(() =>
+    import('./src/components/StructuredData.jsx')
+)
+const LocalBusinessInfo = React.lazy(() =>
+    import('./src/components/LocalBusinessInfo.jsx')
+)
+const LocationContent = React.lazy(() =>
+    import('./src/components/LocationContent.jsx')
+)
+const GoogleBusinessIntegration = React.lazy(() =>
+    import('./src/components/GoogleBusinessIntegration.jsx')
+)
+const LocalSEOFAQ = React.lazy(() =>
+    import('./src/components/LocalSEOFAQ.jsx')
+)
+const Analytics = React.lazy(() =>
+    import('@vercel/analytics/react').then((module) => ({
+        default: module.Analytics,
+    }))
+)
+const SpeedInsights = React.lazy(() =>
+    import('@vercel/speed-insights/react').then((module) => ({
+        default: module.SpeedInsights,
+    }))
+)
+
 const DANGEROUS = new Set(['__proto__', 'prototype', 'constructor'])
 const clean = (k) => (DANGEROUS.has(k) ? undefined : k)
+
+const renderSectionSkeleton = (height = 'h-64') => (
+    <div
+        className="mx-auto max-w-7xl px-4 py-12 sm:px-6 lg:px-8"
+        aria-hidden="true"
+    >
+        <div
+            className={`animate-pulse rounded-2xl bg-gray-200/70 dark:bg-gray-700/40 ${height}`}
+        />
+    </div>
+)
 
 export default function App() {
     const [appState, setAppState] = React.useState({
@@ -167,7 +197,12 @@ export default function App() {
     return (
         <div className="flex min-h-screen flex-col">
             <div id="home"></div>
-            <StructuredData pageMode="listing" products={appState.products} />
+            <React.Suspense fallback={null}>
+                <StructuredData
+                    pageMode="listing"
+                    products={appState.products}
+                />
+            </React.Suspense>
             <AgeGate />
             {/* Navigation */}
             <nav
@@ -609,11 +644,17 @@ export default function App() {
                     </div>
                 </div>
                 {/* Location Content */}
-                <LocationContent />
+                <React.Suspense fallback={renderSectionSkeleton('h-72')}>
+                    <LocationContent />
+                </React.Suspense>
                 {/* Google Business Integration */}
-                <GoogleBusinessIntegration />
+                <React.Suspense fallback={renderSectionSkeleton('h-80')}>
+                    <GoogleBusinessIntegration />
+                </React.Suspense>
                 {/* Local SEO FAQ */}
-                <LocalSEOFAQ />
+                <React.Suspense fallback={renderSectionSkeleton('h-72')}>
+                    <LocalSEOFAQ />
+                </React.Suspense>
                 {/* Contact Section */}
                 <div id="contact" className="bg-white py-12 dark:bg-gray-800">
                     <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
@@ -633,7 +674,11 @@ export default function App() {
                             className="mt-10 flex justify-center"
                         >
                             <div className="lg:w-1/2">
-                                <LocalBusinessInfo />
+                                <React.Suspense
+                                    fallback={renderSectionSkeleton('h-96')}
+                                >
+                                    <LocalBusinessInfo />
+                                </React.Suspense>
                             </div>
                         </div>
                     </div>
@@ -867,18 +912,31 @@ export default function App() {
                             legal under the 2018 Farm Bill.
                         </p>
                         <div className="mt-4 text-center">
-                            <LocalBusinessInfo
-                                variant="inline"
-                                className="text-sm text-black dark:text-white"
-                            />
+                            <React.Suspense
+                                fallback={
+                                    <span
+                                        className="inline-block h-4 w-48 animate-pulse rounded bg-gray-200/70 dark:bg-gray-700/40"
+                                        aria-hidden="true"
+                                    />
+                                }
+                            >
+                                <LocalBusinessInfo
+                                    variant="inline"
+                                    className="text-sm text-black dark:text-white"
+                                />
+                            </React.Suspense>
                         </div>
                     </div>
                 </div>
             </footer>
             {/* ... */}
-            <Analytics />
+            <React.Suspense fallback={null}>
+                <Analytics />
+            </React.Suspense>
             {/* ... */}
-            <SpeedInsights />
+            <React.Suspense fallback={null}>
+                <SpeedInsights />
+            </React.Suspense>
         </div>
     )
 }

--- a/src/utils/businessInfo.js
+++ b/src/utils/businessInfo.js
@@ -1,0 +1,21 @@
+export const businessInfo = {
+    name: 'Route 66 Hemp',
+    address: {
+        street: '14076 State Hwy Z',
+        city: 'St Robert',
+        state: 'MO',
+        zip: '65584',
+        full: '14076 State Hwy Z, St Robert, MO 65584',
+    },
+    phone: '+1 (573) 677-6418',
+    phoneFormatted: '(573) 677-6418',
+    phoneLink: 'tel:+15736776418',
+    email: 'route66hemp@gmail.com',
+    emailLink: 'mailto:route66hemp@gmail.com',
+    website: 'https://www.route66hemp.com',
+    coordinates: {
+        lat: 37.8349,
+        lng: -92.09725,
+    },
+}
+

--- a/src/utils/seoHelpers.js
+++ b/src/utils/seoHelpers.js
@@ -1,24 +1,7 @@
+import { businessInfo } from './businessInfo.js'
+
 // SEO utility functions for local business optimization
-export const businessInfo = {
-    name: 'Route 66 Hemp',
-    address: {
-        street: '14076 State Hwy Z',
-        city: 'St Robert',
-        state: 'MO',
-        zip: '65584',
-        full: '14076 State Hwy Z, St Robert, MO 65584',
-    },
-    phone: '+1 (573) 677-6418',
-    phoneFormatted: '(573) 677-6418',
-    phoneLink: 'tel:+15736776418',
-    email: 'route66hemp@gmail.com',
-    emailLink: 'mailto:route66hemp@gmail.com',
-    website: 'https://www.route66hemp.com',
-    coordinates: {
-        lat: 37.8349,
-        lng: -92.09725,
-    },
-}
+export { businessInfo }
 
 export const generateLocalTitle = (pageTitle, includeLocation = true) => {
     const location = includeLocation ? ` | St Robert, MO` : ''

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     plugins: [react(), tailwindcss()],
     build: {
         // outDir defaults to "dist".  Keep or change as you like.
+        cssCodeSplit: true,
         rollupOptions: {
             input: {
                 main: 'index.html',
@@ -14,6 +15,31 @@ export default defineConfig({
                 terms: 'terms-of-service.html',
                 cookie: 'cookie-policy.html',
             },
+            output: {
+                manualChunks(id) {
+                    if (id.includes('node_modules')) {
+                        if (id.includes('react')) {
+                            return 'react-vendor'
+                        }
+                        if (id.includes('@vercel')) {
+                            return 'observability'
+                        }
+                        if (id.includes('@fortawesome')) {
+                            return 'icons'
+                        }
+                        return 'vendor'
+                    }
+                },
+            },
         },
+    },
+    optimizeDeps: {
+        include: [
+            '@vercel/analytics/react',
+            '@vercel/speed-insights/react',
+            '@fortawesome/free-brands-svg-icons',
+            '@fortawesome/free-regular-svg-icons',
+            '@fortawesome/free-solid-svg-icons',
+        ],
     },
 })


### PR DESCRIPTION
## Summary
- lazy load the below-the-fold marketing sections and analytics widgets with Suspense fallbacks to shrink the main entry bundle
- isolate the business profile data so other SEO helpers can be tree-shaken when unused
- split vendor code into targeted chunks through Rollup manualChunks and ensure lazily loaded deps are pre-bundled

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8c6d369688329a459158337ed3fde