### PR TITLE
fix: update legal policy urls to clean format

### DIFF
--- a/app.jsx
+++ b/app.jsx
@@ -874,7 +874,7 @@ export default function App() {
                                 <ul className="mt-4 space-y-4">
                                     <li>
                                         <a
-                                            href="/privacy-policy.html"
+                                            href="/privacy-policy/"
                                             className="text-base text-black hover:text-gray-600 dark:text-white dark:hover:text-gray-300"
                                             title="Privacy Policy"
                                         >
@@ -883,7 +883,7 @@ export default function App() {
                                     </li>
                                     <li>
                                         <a
-                                            href="/terms-of-service.html"
+                                            href="/terms-of-service/"
                                             className="text-base text-black hover:text-gray-600 dark:text-white dark:hover:text-gray-300"
                                         >
                                             Terms and Conditions
@@ -891,7 +891,7 @@ export default function App() {
                                     </li>
                                     <li>
                                         <a
-                                            href="/cookie-policy.html"
+                                            href="/cookie-policy/"
                                             className="text-base text-black hover:text-gray-600 dark:text-white dark:hover:text-gray-300"
                                             title="Cookie Policy"
                                         >

--- a/cookie-policy.html
+++ b/cookie-policy.html
@@ -131,7 +131,7 @@
         <div id="cookie-banner">
           <span>
             We use cookies to improve your browsing experience and analyze site traffic.
-            <a href="/privacy-policy.html" target="_blank">Learn More</a>
+            <a href="/privacy-policy/" target="_blank">Learn More</a>
           </span>
           <div class="actions">
             <button id="cookie-accept">Accept</button>

--- a/index.html
+++ b/index.html
@@ -141,7 +141,7 @@
         <div id="cookie-banner">
           <span>
             We use cookies to improve your browsing experience and analyze site traffic.
-            <a href="/privacy-policy.html" target="_blank" rel="noopener noreferrer" aria-label="Read our Privacy Policy">Read our Privacy Policy</a>
+            <a href="/privacy-policy/" target="_blank" rel="noopener noreferrer" aria-label="Read our Privacy Policy">Read our Privacy Policy</a>
           </span>
           <div class="actions">
             <button id="cookie-accept">Accept</button>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -598,7 +598,7 @@
         <div id="cookie-banner">
           <span>
             We use cookies to improve your browsing experience and analyze site traffic.
-            <a href="/privacy-policy.html" target="_blank">Learn More</a>
+            <a href="/privacy-policy/" target="_blank">Learn More</a>
           </span>
           <div class="actions">
             <button id="cookie-accept">Accept</button>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -6,9 +6,9 @@ Sitemap: https://route66hemp.com/sitemap.xml
 
 # Allow access to important pages
 Allow: /
-Allow: /privacy-policy.html
-Allow: /terms-of-service.html
-Allow: /cookie-policy.html
+Allow: /privacy-policy/
+Allow: /terms-of-service/
+Allow: /cookie-policy/
 
 # Block access to development files
 Disallow: /*.json$

--- a/terms-of-service.html
+++ b/terms-of-service.html
@@ -89,7 +89,7 @@
         <div id="cookie-banner">
           <span>
             We use cookies to improve your browsing experience and analyze site traffic.
-            <a href="/privacy-policy.html" target="_blank">Learn More</a>
+            <a href="/privacy-policy/" target="_blank">Learn More</a>
           </span>
           <div class="actions">
             <button id="cookie-accept">Accept</button>


### PR DESCRIPTION
## Summary
- update legal policy links across the app and standalone pages to use clean trailing-slash URLs
- align robots.txt allowances with the new clean URLs

## Testing
- npm run lint *(fails: Missing dependency eslint-plugin-react)*
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8cd309cf48329b6fe2461b58df6c3